### PR TITLE
Local training policy: ensure scheduled queue size is bounded

### DIFF
--- a/compiler_opt/rl/gin_configs/ppo_nn_agent.gin
+++ b/compiler_opt/rl/gin_configs/ppo_nn_agent.gin
@@ -11,6 +11,7 @@ train_eval.num_iterations=200
 train_eval.batch_size=128
 train_eval.train_sequence_length=16
 train_eval.deploy_policy_name='saved_collect_policy'
+train_eval.use_stale_results=False
 
 get_observation_processing_layer_creator.quantile_file_dir='compiler_opt/rl/vocab'
 get_observation_processing_layer_creator.with_z_score_normalization = False

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -61,7 +61,8 @@ def train_eval(agent_name='ppo',
                num_iterations=100,
                batch_size=64,
                train_sequence_length=1,
-               deploy_policy_name='saved_policy'):
+               deploy_policy_name='saved_policy',
+               use_stale_results=False):
   """Train for LLVM inliner."""
   root_dir = FLAGS.root_dir
 
@@ -105,7 +106,8 @@ def train_eval(agent_name='ppo',
       num_workers=FLAGS.num_workers,
       num_modules=FLAGS.num_modules,
       runner=runner.collect_data,
-      parser=sequence_example_iterator_fn)
+      parser=sequence_example_iterator_fn,
+      use_stale_results=use_stale_results)
 
   for policy_iteration in range(num_policy_iterations):
     policy_path = os.path.join(root_dir, 'policy', str(policy_iteration))
@@ -119,6 +121,8 @@ def train_eval(agent_name='ppo',
 
   # Save final policy.
   saver.save(root_dir)
+  # Wait for all the workers to finish.
+  data_collector.close_pool()
 
 
 def main(_):


### PR DESCRIPTION
When we have unfinished tasks that we don't need to wait for, we risk entering into a timing issue where the rate of queueing more work is larger than the rate of clearing worker processes.

To both keep the system well-performing and robust to such corner cases, we track the unfinished work. We require the data collection plugin (e.g. inliner, regalloc) to have a timeout - so plugins are guaranteed to finish, once a worker acquires them. If a watermark of unfinished work is hit, we report and wait for it to drain (up to that watermark). If this happens frequently, the user should increase deadlines or check the corpus (maybe there are too many very large modules that take a long time to compile)

This design quite easily lends us the opportunity to use the data collected from work from previous training ('stale' data). The option is available via a flag.

Separately, when finishing all work, we also need to graciously close and join the current pool, otherwise we get errors due to timing between: pool workers exiting, main process exiting, and pool workers' communication channels being severed because of the latter. Note that in google3, forcefully terminating the pool causes the spanned processes (clang) to crash (expected), but that also appears to pull down the main process - we should investigate this separately - it'd enable us exit more quickly.