### PR TITLE
fix issues with gin bindings in demo

### DIFF
--- a/docs/demo/demo.md
+++ b/docs/demo/demo.md
@@ -233,7 +233,8 @@ rm -rf $DEFAULT_TRACE &&
     compiler_opt/tools/generate_default_trace.py \
     --data_path=$CORPUS \
     --output_path=$DEFAULT_TRACE \
-    --compile_task=inlining \
+    --gin_files=compiler_opt/rl/inlining/gin_configs/common.gin \
+    --gin_bindings=config_registry.get_configuration.implementation=@configs.InliningConfig
     --gin_bindings=clang_path="'$LLVM_INSTALLDIR/bin/clang'" \
     --gin_bindings=llvm_size_path="'$LLVM_INSTALLDIR/bin/llvm-size'" \
     --sampling_rate=0.2
@@ -310,6 +311,7 @@ python3 compiler_opt/tools/generate_default_trace.py \
   --policy_path=$OUTPUT_DIR/saved_policy \
   --output_performance_path=$OUTPUT_PERFORMANCE_PATH \
   --compile_task=inlining \
+  --gin_files=compiler_opt/rl/inlining/gin_configs/common.gin \
   --gin_bindings=clang_path="'$LLVM_INSTALLDIR/bin/clang'" \
   --gin_bindings=llvm_size_path"'=$LLVM_INSTALLDIR/bin/llvm-size'" \
   --sampling_rate=0.2


### PR DESCRIPTION
With the recent transition to using gin to handle configuration so that adding more problem types is significantly more scalable (2ba448732b5c9aa9ed221ac70a0009293651701e), it seems like a couple things were overlooked in the inlining demo. The `compile_task` flag has been deprecated, but it was still present in the demo. There is also no mapping between `clang_path` and `llvm_size_path` and the actual config variables they need to alter (`runners.InliningRunner.*`). Finally, there is no flag providing the configuration implementation, which is needed according to the documentation in `compiler_opt/rl/problem_configuration.py`. This PR makes a couple quick fixes so that the demo functions as intended.