### PR TITLE
Modify regalloc runner to prevent needing a ThinLTO corpus for generating a default trace

### DIFF
--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -72,7 +72,11 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
     log_path = os.path.join(working_dir, 'log')
     output_native_path = os.path.join(working_dir, 'native')
 
-    input_ir_path, cmd_path, thinlto_index_path = file_paths
+    input_ir_path = cmd_path = thinlto_index_path = None
+    if len(file_paths) == 3:
+        input_ir_path, cmd_path, thinlto_index_path = file_paths
+    else:
+        input_ir_path, cmd_path = file_paths
 
     result = {}
     try:


### PR DESCRIPTION
Currently, when running `generate_default_trace.py` against the regalloc problem, it errors out when not using a ThinLTO corpus due to the expansion of the `file_paths` variable. This patch preserves functionality for the ThinLTO case while also allowing running `generate_default_trace` against the regalloc runner without using a ThinLTO corpus.