### PR TITLE
Enable linting and type checking.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           pip install pytest pytype pylint
       - name: Type check
         run: |
-          pytype --protocols .
+          pytype --protocols -j auto .
       - name: Lint
         run: |
           pylint --rcfile .pylintrc **/*.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,14 @@ jobs:
           pip install pytest pytype==2022.06.06 pylint==2.14.1
           pylint --version
       - name: Type check
+        id: typecheck
         run: |
           pytype --protocols -j auto .
       - name: Lint
+        continue-on-error: true
         run: |
           pylint --rcfile .pylintrc --recursive yes .
       - name: Test
+        if: steps.typecheck.conclusion == 'success'
         run: |
           pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,14 +23,11 @@ jobs:
           pip install pytest pytype==2022.06.06 pylint==2.14.1
           pylint --version
       - name: Type check
-        id: typecheck
         run: |
           pytype --protocols -j auto .
-      - name: Lint
-        continue-on-error: true
-        run: |
-          pylint --rcfile .pylintrc --recursive yes .
       - name: Test
-        if: steps.typecheck.conclusion == 'success'
         run: |
           pytest
+      - name: Lint
+        run: |
+          pylint --rcfile .pylintrc --recursive yes .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           pytype --protocols -j auto .
       - name: Lint
         run: |
-          pylint --rcfile .pylintrc **/*.py
+          pylint --rcfile .pylintrc --recursive yes .
       - name: Test
         run: |
           pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytype pylint
+          pip install pytest pytype==2022.06.06 pylint==2.14.1
+          pylint --version
       - name: Type check
         run: |
           pytype --protocols -j auto .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytype pylint
+      - name: Type check
+        run: |
+          pytype --protocols .
+      - name: Lint
+        run: |
+          pylint --rcfile .pylintrc **/*.py
       - name: Test
         run: |
           pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,430 @@
+# This Pylint rcfile contains a best-effort configuration to uphold the
+# best-practices and style described in the Google Python style guide:
+#   https://google.github.io/styleguide/pyguide.html
+#
+# Its canonical open-source location is:
+#   https://google.github.io/styleguide/pylintrc
+
+[MASTER]
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=third_party
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=abstract-method,
+        apply-builtin,
+        arguments-differ,
+        attribute-defined-outside-init,
+        backtick,
+        bad-option-value,
+        basestring-builtin,
+        buffer-builtin,
+        c-extension-no-member,
+        consider-using-enumerate,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        delslice-method,
+        div-method,
+        duplicate-code,
+        eq-without-hash,
+        execfile-builtin,
+        file-builtin,
+        filter-builtin-not-iterating,
+        fixme,
+        getslice-method,
+        global-statement,
+        hex-method,
+        idiv-method,
+        implicit-str-concat,
+        import-error,
+        import-self,
+        import-star-module-level,
+        inconsistent-return-statements,
+        input-builtin,
+        intern-builtin,
+        invalid-str-codec,
+        locally-disabled,
+        long-builtin,
+        long-suffix,
+        map-builtin-not-iterating,
+        misplaced-comparison-constant,
+        missing-function-docstring,
+        metaclass-assignment,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        no-init,  # added
+        no-member,
+        no-name-in-module,
+        no-self-use,
+        nonzero-method,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        parameter-unpacking,
+        print-statement,
+        raising-string,
+        range-builtin-not-iterating,
+        raw_input-builtin,
+        rdiv-method,
+        reduce-builtin,
+        relative-import,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        signature-differs,
+        standarderror-builtin,
+        suppressed-message,
+        sys-max-int,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-locals,
+        too-many-nested-blocks,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        trailing-newlines,
+        unichr-builtin,
+        unicode-builtin,
+        unnecessary-pass,
+        unpacking-in-except,
+        useless-else-on-loop,
+        useless-object-inheritance,
+        useless-suppression,
+        using-cmp-argument,
+        wrong-import-order,
+        xrange-builtin,
+        zip-builtin-not-iterating,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit.  The internal Google style guide mandates 2
+# spaces.  Google's externaly-published style guide says 4, consistent with
+# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
+# projects (like TensorFlow).
+indent-string='  '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging,tensorflow.io.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException
+

--- a/.pylintrc
+++ b/.pylintrc
@@ -102,6 +102,7 @@ disable=abstract-method,
         no-member,
         no-name-in-module,
         no-self-use,
+	no-value-for-parameter, # gin causes false positives
         nonzero-method,
         oct-method,
         old-division,

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = yapf
+indent_width = 2

--- a/compiler_opt/__init__.py
+++ b/compiler_opt/__init__.py
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Ensure flags are initialized for e.g. pytest harness case."""
-
 
 import sys
 

--- a/compiler_opt/rl/__init__.py
+++ b/compiler_opt/rl/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/compiler_opt/rl/agent_creators.py
+++ b/compiler_opt/rl/agent_creators.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """util function to create a tf_agent."""
 
 from typing import Callable
@@ -46,10 +45,10 @@ def _create_behavioral_cloning_agent(
       time_step_spec, action_spec, cloning_network=network, num_outer_dims=2)
 
 
-def _create_dqn_agent(
-    time_step_spec: types.NestedTensorSpec, action_spec: types.NestedTensorSpec,
-    preprocessing_layers: types.NestedLayer,
-    policy_network: types.Network) -> tfa.agents.TFAgent:
+def _create_dqn_agent(time_step_spec: types.NestedTensorSpec,
+                      action_spec: types.NestedTensorSpec,
+                      preprocessing_layers: types.NestedLayer,
+                      policy_network: types.Network) -> tfa.agents.TFAgent:
   """Creates a dqn_agent."""
   network = policy_network(
       time_step_spec.observation,
@@ -60,10 +59,10 @@ def _create_dqn_agent(
   return dqn_agent.DqnAgent(time_step_spec, action_spec, q_network=network)
 
 
-def _create_ppo_agent(
-    time_step_spec: types.NestedTensorSpec, action_spec: types.NestedTensorSpec,
-    preprocessing_layers: types.NestedLayer,
-    policy_network: types.Network) -> tfa.agents.TFAgent:
+def _create_ppo_agent(time_step_spec: types.NestedTensorSpec,
+                      action_spec: types.NestedTensorSpec,
+                      preprocessing_layers: types.NestedLayer,
+                      policy_network: types.Network) -> tfa.agents.TFAgent:
   """Creates a ppo_agent."""
 
   actor_network = policy_network(
@@ -83,13 +82,12 @@ def _create_ppo_agent(
 
 
 @gin.configurable
-def create_agent(
-    agent_name: constant.AgentName,
-    time_step_spec: types.NestedTensorSpec,
-    action_spec: types.NestedTensorSpec,
-    preprocessing_layer_creator: Callable[[types.TensorSpec],
-                                          tf.keras.layers.Layer],
-    policy_network: types.Network):
+def create_agent(agent_name: constant.AgentName,
+                 time_step_spec: types.NestedTensorSpec,
+                 action_spec: types.NestedTensorSpec,
+                 preprocessing_layer_creator: Callable[[types.TensorSpec],
+                                                       tf.keras.layers.Layer],
+                 policy_network: types.Network):
   """Creates a tfa.agents.TFAgent object.
 
   Args:
@@ -109,18 +107,18 @@ def create_agent(
   assert policy_network is not None
   assert agent_name is not None
 
-  preprocessing_layers = tf.nest.map_structure(
-      preprocessing_layer_creator, time_step_spec.observation)
+  preprocessing_layers = tf.nest.map_structure(preprocessing_layer_creator,
+                                               time_step_spec.observation)
 
   if agent_name == constant.AgentName.BEHAVIORAL_CLONE:
     return _create_behavioral_cloning_agent(time_step_spec, action_spec,
                                             preprocessing_layers,
                                             policy_network)
   elif agent_name == constant.AgentName.DQN:
-    return _create_dqn_agent(time_step_spec, action_spec,
-                             preprocessing_layers, policy_network)
+    return _create_dqn_agent(time_step_spec, action_spec, preprocessing_layers,
+                             policy_network)
   elif agent_name == constant.AgentName.PPO:
-    return _create_ppo_agent(time_step_spec, action_spec,
-                             preprocessing_layers, policy_network)
+    return _create_ppo_agent(time_step_spec, action_spec, preprocessing_layers,
+                             policy_network)
   else:
     raise ValueError('Unknown agent: {}'.format(agent_name))

--- a/compiler_opt/rl/agent_creators.py
+++ b/compiler_opt/rl/agent_creators.py
@@ -121,4 +121,4 @@ def create_agent(agent_name: constant.AgentName,
     return _create_ppo_agent(time_step_spec, action_spec, preprocessing_layers,
                              policy_network)
   else:
-    raise ValueError('Unknown agent: {}'.format(agent_name))
+    raise ValueError(f'Unknown agent: {agent_name}')

--- a/compiler_opt/rl/agent_creators.py
+++ b/compiler_opt/rl/agent_creators.py
@@ -18,8 +18,8 @@ from typing import Callable
 
 import gin
 import tensorflow as tf
-import tf_agents as tfa
 
+from tf_agents.agents import TFAgent
 from tf_agents.agents.behavioral_cloning import behavioral_cloning_agent
 from tf_agents.agents.dqn import dqn_agent
 from tf_agents.agents.ppo import ppo_agent
@@ -29,10 +29,10 @@ from compiler_opt.rl import constant
 from compiler_opt.rl import constant_value_network
 
 
-def _create_behavioral_cloning_agent(
-    time_step_spec: types.NestedTensorSpec, action_spec: types.NestedTensorSpec,
-    preprocessing_layers: types.NestedLayer,
-    policy_network: types.Network) -> tfa.agents.TFAgent:
+def _create_behavioral_cloning_agent(time_step_spec: types.NestedTensorSpec,
+                                     action_spec: types.NestedTensorSpec,
+                                     preprocessing_layers: types.NestedLayer,
+                                     policy_network: types.Network) -> TFAgent:
   """Creates a behavioral_cloning_agent."""
 
   network = policy_network(
@@ -48,7 +48,7 @@ def _create_behavioral_cloning_agent(
 def _create_dqn_agent(time_step_spec: types.NestedTensorSpec,
                       action_spec: types.NestedTensorSpec,
                       preprocessing_layers: types.NestedLayer,
-                      policy_network: types.Network) -> tfa.agents.TFAgent:
+                      policy_network: types.Network) -> TFAgent:
   """Creates a dqn_agent."""
   network = policy_network(
       time_step_spec.observation,
@@ -62,7 +62,7 @@ def _create_dqn_agent(time_step_spec: types.NestedTensorSpec,
 def _create_ppo_agent(time_step_spec: types.NestedTensorSpec,
                       action_spec: types.NestedTensorSpec,
                       preprocessing_layers: types.NestedLayer,
-                      policy_network: types.Network) -> tfa.agents.TFAgent:
+                      policy_network: types.Network) -> TFAgent:
   """Creates a ppo_agent."""
 
   actor_network = policy_network(

--- a/compiler_opt/rl/agent_creators_test.py
+++ b/compiler_opt/rl/agent_creators_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.agent_creators."""
 
 import gin

--- a/compiler_opt/rl/agent_creators_test.py
+++ b/compiler_opt/rl/agent_creators_test.py
@@ -49,7 +49,7 @@ class AgentCreatorsTest(tf.test.TestCase):
         minimum=0,
         maximum=1,
         name='inlining_decision')
-    super(AgentCreatorsTest, self).setUp()
+    super().setUp()
 
   def test_create_behavioral_cloning_agent(self):
     gin.bind_parameter('create_agent.policy_network', q_network.QNetwork)

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -97,7 +97,7 @@ def get_command_line_for_bundle(cmd_file: str,
       '-fprofile-sample-use'
   ]
 
-  with open(cmd_file, 'rb') as f:
+  with open(cmd_file, 'r') as f:
     option_iterator = iter(f.read().split('\0'))
     option = next(option_iterator, None)
     while option:

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -97,7 +97,7 @@ def get_command_line_for_bundle(cmd_file: str,
       '-fprofile-sample-use'
   ]
 
-  with open(cmd_file) as f:
+  with open(cmd_file, 'rb') as f:
     option_iterator = iter(f.read().split('\0'))
     option = next(option_iterator, None)
     while option:

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -101,7 +101,7 @@ def get_command_line_for_bundle(cmd_file: str,
     option_iterator = iter(f.read().split('\0'))
     option = next(option_iterator, None)
     while option:
-      if any([option.startswith(flag) for flag in flags_to_remove]):
+      if any(option.startswith(flag) for flag in flags_to_remove):
         if '=' not in option:
           next(option_iterator, None)
       else:
@@ -375,8 +375,8 @@ class CompilationRunner:
       policy_reward = v[1]
       if k not in reward_stat:
         raise ValueError(
-            'Example %s does not exist under default policy for module %s' %
-            (k, file_paths[0]))
+            (f'Example {k} does not exist under default policy for '
+             'module {file_paths[0]}'))
       default_reward = reward_stat[k].default_reward
       moving_average_reward = reward_stat[k].moving_average_reward
       sequence_example = _overwrite_trajectory_reward(

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -97,7 +97,7 @@ def get_command_line_for_bundle(cmd_file: str,
       '-fprofile-sample-use'
   ]
 
-  with open(cmd_file, 'r') as f:
+  with open(cmd_file, encoding='utf-8') as f:
     option_iterator = iter(f.read().split('\0'))
     option = next(option_iterator, None)
     while option:

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module for running compilation and collect training data."""
 
 import concurrent
@@ -313,6 +312,7 @@ class CompilationRunner:
     if not cancellation_token:
       return None
     ret = WorkerCancellationManager()
+
     def signaler():
       cancellation_token.wait()
       ret.signal()

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.compilation_runner."""
 
 import os
@@ -55,7 +54,7 @@ def _get_sequence_example_with_reward(feature_value, reward):
         }
       }
     }""").substitute(
-        feature_value=feature_value, reward=reward)
+      feature_value=feature_value, reward=reward)
   return text_format.Parse(sequence_example_text, tf.train.SequenceExample())
 
 
@@ -257,9 +256,11 @@ class CompilationRunnerTest(tf.test.TestCase):
     with self.assertRaises(subprocess.TimeoutExpired):
       compilation_runner.start_cancellable_process(
           ['bash', '-c', 'sleep 1s ; touch ' + sentinel_file],
-          timeout=0.5, cancellation_manager=None)
+          timeout=0.5,
+          cancellation_manager=None)
     time.sleep(2)
     self.assertFalse(os.path.exists(sentinel_file))
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/compiler_opt/rl/constant.py
+++ b/compiler_opt/rl/constant.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Constants for policy training."""
 
 import enum

--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -46,6 +46,7 @@ class ConstantValueNetwork(network.Network):
     self._constant_output_val = constant_output_val
 
   def call(self, observation, step_type=None, network_state=(), training=False):
+    _ = (step_type, training)
     shape = nest_utils.get_outer_array_shape(observation,
                                              self._input_tensor_spec)
     return tf.constant(

--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -40,7 +40,7 @@ class ConstantValueNetwork(network.Network):
     Raises:
       ValueError: If input_tensor_spec is not an instance of network.InputSpec.
     """
-    super(ConstantValueNetwork, self).__init__(
+    super().__init__(
         input_tensor_spec=input_tensor_spec, state_spec=(), name=name)
 
     self._constant_output_val = constant_output_val

--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Constant Value Network that always predicts a constant value."""
 
 import gin

--- a/compiler_opt/rl/constant_value_network_test.py
+++ b/compiler_opt/rl/constant_value_network_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.constant_value_network."""
 
 import tensorflow as tf

--- a/compiler_opt/rl/data_collector.py
+++ b/compiler_opt/rl/data_collector.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Data collection module."""
 
 import abc
@@ -81,10 +80,11 @@ class DataCollector(metaclass=abc.ABCMeta):
 class EarlyExitChecker:
   """Class which checks if it is ok to early-exit from data collection."""
 
-  def __init__(self,  # pylint: disable=dangerous-default-value
-               num_modules: int,
-               deadline: float = DEADLINE_IN_SECONDS,
-               thresholds: Tuple[Tuple[float, float], ...] = WAIT_TERMINATION):
+  def __init__(
+      self,  # pylint: disable=dangerous-default-value
+      num_modules: int,
+      deadline: float = DEADLINE_IN_SECONDS,
+      thresholds: Tuple[Tuple[float, float], ...] = WAIT_TERMINATION):
     """Initializes the early exit checker.
 
     Args:

--- a/compiler_opt/rl/data_collector_test.py
+++ b/compiler_opt/rl/data_collector_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylint: disable=protected-access
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_collector_test.py
+++ b/compiler_opt/rl/data_collector_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for data_collector."""
 
 from unittest import mock

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """util function to create training datasets."""
 
 from typing import Callable, List
@@ -143,8 +142,8 @@ def create_parser_fn(
 
 def create_sequence_example_dataset_fn(
     agent_name: constant.AgentName, time_step_spec: types.NestedSpec,
-    action_spec: types.NestedSpec, batch_size: int, train_sequence_length: int
-) -> Callable[[List[str]], tf.data.Dataset]:
+    action_spec: types.NestedSpec, batch_size: int,
+    train_sequence_length: int) -> Callable[[List[str]], tf.data.Dataset]:
   """Get a function that creates a dataset from serialized sequence examples.
 
   Args:
@@ -236,8 +235,8 @@ def create_file_dataset_fn(
 
 def create_tfrecord_dataset_fn(
     agent_name: constant.AgentName, time_step_spec: types.NestedSpec,
-    action_spec: types.NestedSpec, batch_size: int, train_sequence_length: int
-) -> Callable[[List[str]], tf.data.Dataset]:
+    action_spec: types.NestedSpec, batch_size: int,
+    train_sequence_length: int) -> Callable[[List[str]], tf.data.Dataset]:
   """Get a function that creates an dataset from tfrecord.
 
   Args:

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylint: disable=protected-access
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -83,7 +83,7 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
         name='live_interval_weight',
         minimum=-100,
         maximum=20)
-    super(DataReaderTest, self).setUp()
+    super().setUp()
 
   @parameterized.named_parameters(
       ('SequenceExampleDatasetFn',

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -95,9 +95,9 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
         self._agent_name, is_action_discrete=True)
 
     data_source = None
-    if test_fn == data_reader.create_sequence_example_dataset_fn:
+    if test_fn == data_reader.create_sequence_example_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = [example.SerializeToString() for _ in range(100)]
-    elif test_fn == data_reader.create_tfrecord_dataset_fn:
+    elif test_fn == data_reader.create_tfrecord_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = os.path.join(self.get_temp_dir(), 'data_tfrecord')
       _write_tmp_tfrecord(data_source, example, 100)
 
@@ -132,9 +132,9 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
         self._agent_name, is_action_discrete=True)
 
     data_source = None
-    if test_fn == data_reader.create_sequence_example_dataset_fn:
+    if test_fn == data_reader.create_sequence_example_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = [example.SerializeToString() for _ in range(100)]
-    elif test_fn == data_reader.create_tfrecord_dataset_fn:
+    elif test_fn == data_reader.create_tfrecord_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = os.path.join(self.get_temp_dir(), 'data_tfrecord')
       _write_tmp_tfrecord(data_source, example, 100)
 
@@ -163,9 +163,9 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
         self._agent_name, is_action_discrete=False)
 
     data_source = None
-    if test_fn == data_reader.create_sequence_example_dataset_fn:
+    if test_fn == data_reader.create_sequence_example_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = [example.SerializeToString() for _ in range(100)]
-    elif test_fn == data_reader.create_tfrecord_dataset_fn:
+    elif test_fn == data_reader.create_tfrecord_dataset_fn:  # pylint: disable=comparison-with-callable
       data_source = os.path.join(self.get_temp_dir(), 'data_tfrecord')
       _write_tmp_tfrecord(data_source, example, 100)
 

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.data_reader."""
 
 import os
@@ -112,8 +111,7 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
     experience = next(data_iterator)
     self.assertIsInstance(experience, trajectory.Trajectory)
     self.assertAllEqual([2, 3], experience.step_type.shape)
-    self.assertCountEqual(['feature_key'],
-                          experience.observation.keys())
+    self.assertCountEqual(['feature_key'], experience.observation.keys())
     self.assertAllEqual([[1, 1, 1], [1, 1, 1]],
                         experience.observation['feature_key'])
     self.assertAllEqual([[0, 0, 0], [0, 0, 0]], experience.action)

--- a/compiler_opt/rl/feature_ops.py
+++ b/compiler_opt/rl/feature_ops.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """operations to transform features (observations)."""
 
 import os

--- a/compiler_opt/rl/feature_ops.py
+++ b/compiler_opt/rl/feature_ops.py
@@ -59,6 +59,7 @@ def get_normalize_fn(quantile: List[float],
   """Return a normalization function to normalize the input feature."""
 
   if not preprocessing_fn:
+    # pylint: disable=unnecessary-lambda-assignment
     preprocessing_fn = lambda x: x
   processed_quantile = [preprocessing_fn(x) for x in quantile]
   mean = np.mean(processed_quantile)

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -30,7 +30,8 @@ def _get_sqrt_z_score_preprocessing_fn_cross_product():
     for z_score in [True, False]:
       for preprocessing_fn in [None, lambda x: x * x]:
         # pylint: disable=line-too-long
-        test_name = (f'sqrt_{sqrt}_zscore_{z_score}_preprocessfn_{preprocessing_fn}')
+        test_name = (
+            f'sqrt_{sqrt}_zscore_{z_score}_preprocessfn_{preprocessing_fn}')
         testcases.append((test_name, sqrt, z_score, preprocessing_fn))
   return testcases
 

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.feature_ops."""
 
 import os

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -39,7 +39,7 @@ class FeatureUtilsTest(tf.test.TestCase, parameterized.TestCase):
 
   def setUp(self):
     self._quantile_file_dir = os.path.join(constant.BASE_DIR, 'testdata')
-    super(FeatureUtilsTest, self).setUp()
+    super().setUp()
 
   def test_build_quantile_map(self):
     quantile_map = feature_ops.build_quantile_map(self._quantile_file_dir)

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -29,8 +29,8 @@ def _get_sqrt_z_score_preprocessing_fn_cross_product():
   for sqrt in [True, False]:
     for z_score in [True, False]:
       for preprocessing_fn in [None, lambda x: x * x]:
-        test_name = ('sqrt_%s_zscore_%s_preprocessfn_%s' %
-                     (sqrt, z_score, preprocessing_fn))
+        # pylint: disable=line-too-long
+        test_name = (f'sqrt_{sqrt}_zscore_{z_score}_preprocessfn_{preprocessing_fn}')
         testcases.append((test_name, sqrt, z_score, preprocessing_fn))
   return testcases
 

--- a/compiler_opt/rl/gin_external_configurables.py
+++ b/compiler_opt/rl/gin_external_configurables.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Declaration of a few external GIN configurable functions."""
 
 from gin import config

--- a/compiler_opt/rl/inlining/__init__.py
+++ b/compiler_opt/rl/inlining/__init__.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Implementation of the 'inlining for size' problem."""
 
 import gin

--- a/compiler_opt/rl/inlining/config.py
+++ b/compiler_opt/rl/inlining/config.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Inlining Training config."""
 
 import gin

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -103,12 +103,11 @@ class InliningRunner(compilation_runner.CompilationRunner):
           cancellation_manager=cancellation_manager,
           want_output=True)
       if not output_bytes:
-        raise RuntimeError('Empty llvm-size output: %s' %
-                           ' '.join(command_line))
+        raise RuntimeError(f'Empty llvm-size output: {" ".join(command_line)}')
       output = output_bytes.decode('utf-8')
       tmp = output.split('\n')
       if len(tmp) != 3:
-        raise RuntimeError('Wrong llvm-size output %s' % output)
+        raise RuntimeError(f'Wrong llvm-size output {output}')
       tmp = tmp[1].split('\t')
       native_size = int(tmp[0])
 

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module for collect data of inlining-for-size."""
 
 import io

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -41,7 +41,7 @@ class InliningRunner(compilation_runner.CompilationRunner):
   """
 
   def __init__(self, llvm_size_path: str, *args, **kwargs):
-    super(InliningRunner, self).__init__(*args, **kwargs)
+    super().__init__(*args, **kwargs)
     self._llvm_size_path = llvm_size_path
 
   def _compile_fn(

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module for collecting data locally."""
 
 import itertools
@@ -88,6 +87,7 @@ class LocalDataCollector(data_collector.DataCollector):
     jobs = [(file_paths, policy_path,
              self._reward_stat_map['-'.join(file_paths)], cancellation_token)
             for file_paths in sampled_file_paths]
+
     # Make sure we're not missing failures in workers. All but
     # ProcessKilledError, which we want to ignore.
     def error_callback(e):
@@ -121,6 +121,7 @@ class LocalDataCollector(data_collector.DataCollector):
 
     def wait_for_termination():
       early_exit = self._exit_checker_ctor(num_modules=self._num_modules)
+
       def get_num_finished_work():
         finished_work = sum(res.ready() for res in results)
         return finished_work
@@ -133,12 +134,10 @@ class LocalDataCollector(data_collector.DataCollector):
     current_work = [
         (paths, res) for paths, res in zip(sampled_file_paths, results)
     ]
-    finished_work = [
-        (paths, res) for paths, res in current_work if res.ready()
+    finished_work = [(paths, res) for paths, res in current_work if res.ready()]
+    successful_work = [
+        (paths, res) for paths, res in finished_work if res.successful()
     ]
-    successful_work = [(paths, res)
-                       for paths, res in finished_work
-                       if res.successful()]
     failures = len(finished_work) - len(successful_work)
 
     logging.info(('%d of %d modules finished in %d seconds (%d failures).'),

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -41,7 +41,7 @@ class LocalDataCollector(data_collector.DataCollector):
                                                compilation_runner.RewardStat]]],
       exit_checker_ctor=data_collector.EarlyExitChecker):
     # TODO(mtrofin): type exit_checker_ctor when we get typing.Protocol support
-    super(LocalDataCollector, self).__init__()
+    super().__init__()
 
     self._file_paths = file_paths
     self._num_modules = num_modules

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -131,9 +131,7 @@ class LocalDataCollector(data_collector.DataCollector):
     wait_seconds = wait_for_termination()
     # signal whatever work is left to finish
     ct.signal()
-    current_work = [
-        (paths, res) for paths, res in zip(sampled_file_paths, results)
-    ]
+    current_work = zip(sampled_file_paths, results)
     finished_work = [(paths, res) for paths, res in current_work if res.ready()]
     successful_work = [
         (paths, res) for paths, res in finished_work if res.successful()
@@ -149,7 +147,7 @@ class LocalDataCollector(data_collector.DataCollector):
             for (_, res) in successful_work
         ]))
     total_trajectory_length = sum(
-        [res.get().length for (_, res) in successful_work])
+        res.get().length for (_, res) in successful_work)
     self._reward_stat_map.update({
         '-'.join(file_paths): res.get().reward_stats
         for (file_paths, res) in successful_work

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.local_data_collector."""
 
 import collections
@@ -112,6 +111,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
     mock_compilation_runner.collect_data = mock_collect_data
 
     def create_test_iterator_fn():
+
       def _test_iterator_fn(data_list):
         assert data_list in (
             [_get_sequence_example(feature_value=1).SerializeToString()] * 9,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -26,8 +26,8 @@ from tf_agents.system import system_multiprocessing as multiprocessing
 
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import data_collector
-from google.protobuf import text_format
 from compiler_opt.rl import local_data_collector
+from google.protobuf import text_format
 
 
 def _get_sequence_example(feature_value):
@@ -75,17 +75,18 @@ def mock_collect_data(file_paths, tf_policy_dir, reward_stat, _):
 
 
 class Sleeper(compilation_runner.CompilationRunner):
+  """Test CompilationRunner that just sleeps."""
 
-  def __init__(self, killed, timedout,
-               living):  # pylint: disable super-init-not-called
+  # pylint: disable=super-init-not-called
+  def __init__(self, killed, timedout, living):
     self._killed = killed
     self._timedout = timedout
     self._living = living
     self._lock = mp.Manager().Lock()
 
-  def collect_data(self, file_paths, tf_policy_path, reward_only,
+  def collect_data(self, file_paths, tf_policy_path, reward_stat,
                    cancellation_token):
-    _ = reward_only
+    _ = reward_stat
     cancellation_manager = self._get_cancellation_manager(cancellation_token)
     try:
       compilation_runner.start_cancellable_process(['sleep', '3600s'], 3600,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -85,6 +85,7 @@ class Sleeper(compilation_runner.CompilationRunner):
 
   def collect_data(self, file_paths, tf_policy_path, reward_only,
                    cancellation_token):
+    _ = reward_only
     cancellation_manager = self._get_cancellation_manager(cancellation_token)
     try:
       compilation_runner.start_cancellable_process(['sleep', '3600s'], 3600,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -76,7 +76,8 @@ def mock_collect_data(file_paths, tf_policy_dir, reward_stat, _):
 
 class Sleeper(compilation_runner.CompilationRunner):
 
-  def __init__(self, killed, timedout, living):
+  def __init__(self, killed, timedout,
+               living):  # pylint: disable super-init-not-called
     self._killed = killed
     self._timedout = timedout
     self._living = living

--- a/compiler_opt/rl/policy_saver.py
+++ b/compiler_opt/rl/policy_saver.py
@@ -20,25 +20,25 @@ import os
 import tensorflow as tf
 from tf_agents.policies import policy_saver
 
-OUTPUT_SIGNATURE = "output_spec.json"
+OUTPUT_SIGNATURE = 'output_spec.json'
 
 _TYPE_CONVERSION_DICT = {
-    tf.float32: "float",
-    tf.float64: "double",
-    tf.int8: "int8_t",
-    tf.uint8: "uint8_t",
-    tf.int16: "int16_t",
-    tf.uint16: "uint16_t",
-    tf.int32: "int32_t",
-    tf.uint32: "uint32_t",
-    tf.int64: "int64_t",
-    tf.uint64: "uint64_t",
+    tf.float32: 'float',
+    tf.float64: 'double',
+    tf.int8: 'int8_t',
+    tf.uint8: 'uint8_t',
+    tf.int16: 'int16_t',
+    tf.uint16: 'uint16_t',
+    tf.int32: 'int32_t',
+    tf.uint32: 'uint32_t',
+    tf.int64: 'int64_t',
+    tf.uint64: 'uint64_t',
 }
 
 
 def _split_tensor_name(name):
   """Return tuple (op, port) with the op and int port for the tensor name."""
-  op_port = name.split(":", 2)
+  op_port = name.split(':', 2)
   if len(op_port) == 1:
     return op_port, 0
   else:
@@ -60,7 +60,7 @@ def _get_non_identity_op(tensor):
     The true associated output tensor of the original function in the main
     SavedModel graph.
   """
-  while tensor.op.name.startswith("Identity"):
+  while tensor.op.name.startswith('Identity'):
     tensor = tensor.op.inputs[0]
   return tensor
 
@@ -100,21 +100,20 @@ class PolicySaver(object):
 
     # Dict mapping spec name to spec in flattened action signature.
     sm_action_signature = (
-        tf.nest.flatten(saved_model.signatures["action"].structured_outputs))
+        tf.nest.flatten(saved_model.signatures['action'].structured_outputs))
 
     # Map spec name to index in flattened outputs.
     sm_action_indices = dict(
         (k.name, i) for i, k in enumerate(sm_action_signature))
 
     # List mapping flattened structured outputs to tensors.
-    sm_action_tensors = saved_model.signatures["action"].outputs
+    sm_action_tensors = saved_model.signatures['action'].outputs
 
     # First entry in output list is the decision (action)
     decision_spec = tf.nest.flatten(action_signature.action)
     if len(decision_spec) != 1:
-      raise ValueError(
-          "Expected action decision to have 1 tensor, but saw: {}".format(
-              action_signature.action))
+      raise ValueError(('Expected action decision to have 1 tensor, but '
+                        f'saw: {action_signature.action}'))
 
     # Find the decision's tensor in the flattened output tensor list.
     sm_action_decision = (
@@ -125,12 +124,12 @@ class PolicySaver(object):
     # The first entry in the output_signature file corresponds to the decision.
     (tensor_op, tensor_port) = _split_tensor_name(sm_action_decision.name)
     output_list = [{
-        "logging_name": decision_spec[0].name,  # used in SequenceExample.
-        "tensor_spec": {
-            "name": tensor_op,
-            "port": tensor_port,
-            "type": _TYPE_CONVERSION_DICT[sm_action_decision.dtype],
-            "shape": sm_action_decision.shape.as_list(),
+        'logging_name': decision_spec[0].name,  # used in SequenceExample.
+        'tensor_spec': {
+            'name': tensor_op,
+            'port': tensor_port,
+            'type': _TYPE_CONVERSION_DICT[sm_action_decision.dtype],
+            'shape': sm_action_decision.shape.as_list(),
         }
     }]
     for info_spec in tf.nest.flatten(action_signature.info):
@@ -138,16 +137,16 @@ class PolicySaver(object):
       sm_action_info = _get_non_identity_op(sm_action_info)
       (tensor_op, tensor_port) = _split_tensor_name(sm_action_info.name)
       output_list.append({
-          "logging_name": info_spec.name,  # used in SequenceExample.
-          "tensor_spec": {
-              "name": tensor_op,
-              "port": tensor_port,
-              "type": _TYPE_CONVERSION_DICT[sm_action_info.dtype],
-              "shape": sm_action_info.shape.as_list(),
+          'logging_name': info_spec.name,  # used in SequenceExample.
+          'tensor_spec': {
+              'name': tensor_op,
+              'port': tensor_port,
+              'type': _TYPE_CONVERSION_DICT[sm_action_info.dtype],
+              'shape': sm_action_info.shape.as_list(),
           }
       })
 
-    with tf.io.gfile.GFile(os.path.join(path, OUTPUT_SIGNATURE), "w") as f:
+    with tf.io.gfile.GFile(os.path.join(path, OUTPUT_SIGNATURE), 'w') as f:
       f.write(json.dumps(output_list))
 
   def save(self, root_dir):

--- a/compiler_opt/rl/policy_saver.py
+++ b/compiler_opt/rl/policy_saver.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """util function to save the policy and model config file."""
 
 import json

--- a/compiler_opt/rl/policy_saver_test.py
+++ b/compiler_opt/rl/policy_saver_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.policy_saver."""
 
 import json
@@ -80,6 +79,7 @@ class PolicySaverTest(tf.test.TestCase):
               'shape': [1],
           }
       }], json.loads(tf.io.gfile.GFile(output_signature_fn).read()))
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/compiler_opt/rl/policy_saver_test.py
+++ b/compiler_opt/rl/policy_saver_test.py
@@ -30,7 +30,7 @@ from compiler_opt.rl import policy_saver
 class PolicySaverTest(tf.test.TestCase):
 
   def setUp(self):
-    super(PolicySaverTest, self).setUp()
+    super().setUp()
     observation_spec = tf.TensorSpec(
         dtype=tf.int64, shape=(), name='callee_users')
     self._time_step_spec = time_step.time_step_spec(observation_spec)

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Compilation problem component model.
 
 A 'compilation problem' is an optimization problem with a specific way of
@@ -73,7 +72,6 @@ import tensorflow as tf
 import tf_agents as tfa
 
 from compiler_opt.rl import compilation_runner
-
 
 types = tfa.typing.types
 

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -31,11 +31,13 @@ To use:
 
 * when running the tool, pass:
 
-  `--gin_bindings=config_registry.get_configuration.implementation=@the.implementation.name`
+  `--gin_bindings=config_registry.get_configuration.implementation=\
+    @the.implementation.name`
 
   for example:
 
-  `--gin_bindings=config_registry.get_configuration.implementation=@configs.InliningConfig`
+  `--gin_bindings=config_registry.get_configuration.implementation=\
+    @configs.InliningConfig`
 
 =================
 Conventions

--- a/compiler_opt/rl/random_net_distillation.py
+++ b/compiler_opt/rl/random_net_distillation.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Random Network Distillation Implementation."""
 import gin
 import tensorflow as tf
@@ -186,12 +185,11 @@ class RandomNetworkDistillation():
       addition of external reward + intrinsic reward).
     """
     # compute intrinsic reward for length - 1 horizon
-    intrinsic_reward = self._get_intrinsic_reward(
-        experience.observation)
+    intrinsic_reward = self._get_intrinsic_reward(experience.observation)
 
     normalized_intrinsic_reward = self._intrinsic_reward_normalizer.normalize(
-        intrinsic_reward, clip_value=0,
-        center_mean=False) * self._decay_scale(self._global_step)
+        intrinsic_reward, clip_value=0, center_mean=False) * self._decay_scale(
+            self._global_step)
     self._intrinsic_reward_normalizer.update(intrinsic_reward)
 
     # update the log
@@ -201,7 +199,8 @@ class RandomNetworkDistillation():
     batch_size = experience.reward.shape[0]
     # assign the last time step reward = 0 (no intrinsic reward)
     normalized_intrinsic_reward = tf.concat(
-        [normalized_intrinsic_reward, tf.zeros([batch_size, 1])], axis=1)
+        [normalized_intrinsic_reward,
+         tf.zeros([batch_size, 1])], axis=1)
 
     # reconstruct the reward: external + intrinsic
     reconstructed_reward = experience.reward + normalized_intrinsic_reward

--- a/compiler_opt/rl/random_net_distillation.py
+++ b/compiler_opt/rl/random_net_distillation.py
@@ -198,6 +198,7 @@ class RandomNetworkDistillation():
 
     batch_size = experience.reward.shape[0]
     # assign the last time step reward = 0 (no intrinsic reward)
+    # pylint: disable=unexpected-keyword-arg
     normalized_intrinsic_reward = tf.concat(
         [normalized_intrinsic_reward,
          tf.zeros([batch_size, 1])], axis=1)

--- a/compiler_opt/rl/random_net_distillation_test.py
+++ b/compiler_opt/rl/random_net_distillation_test.py
@@ -78,11 +78,12 @@ class RandomNetworkDistillationTest(tf.test.TestCase, parameterized.TestCase):
     data_iterator = _create_test_data(batch_size=3, sequence_length=3)
 
     # initialize the random_network_distillation instance
-    random_network_distillation = random_net_distillation.RandomNetworkDistillation(
-        time_step_spec=self._time_step_spec,
-        preprocessing_layer_creator=_processing_layer_creator(),
-        encoding_network=encoding_network.EncodingNetwork,
-        update_frequency=self._update_frequency)
+    random_network_distillation = \
+        random_net_distillation.RandomNetworkDistillation(
+          time_step_spec=self._time_step_spec,
+          preprocessing_layer_creator=_processing_layer_creator(),
+          encoding_network=encoding_network.EncodingNetwork,
+          update_frequency=self._update_frequency)
 
     experience = next(data_iterator)
     # test the RND train function return type

--- a/compiler_opt/rl/random_net_distillation_test.py
+++ b/compiler_opt/rl/random_net_distillation_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for random_network_distillation."""
 
 from absl.testing import parameterized

--- a/compiler_opt/rl/random_net_distillation_test.py
+++ b/compiler_opt/rl/random_net_distillation_test.py
@@ -66,7 +66,7 @@ def _create_test_data(batch_size, sequence_length):
 class RandomNetworkDistillationTest(tf.test.TestCase, parameterized.TestCase):
 
   def setUp(self):
-    super(RandomNetworkDistillationTest, self).setUp()
+    super().setUp()
     self._update_frequency = 1
     observation_spec = {
         'edge_count': tf.TensorSpec(

--- a/compiler_opt/rl/regalloc/__init__.py
+++ b/compiler_opt/rl/regalloc/__init__.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Implementation of the 'regalloc' problem."""
 
 import gin

--- a/compiler_opt/rl/regalloc/config.py
+++ b/compiler_opt/rl/regalloc/config.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Register allocation training config."""
 
 import gin

--- a/compiler_opt/rl/regalloc/config.py
+++ b/compiler_opt/rl/regalloc/config.py
@@ -118,6 +118,7 @@ def get_observation_processing_layer_creator(quantile_file_dir=None,
         features = [tf.where(tf.math.is_inf(tf.expand_dims(obs, -1)), 1.0, 0.0)]
         obs = tf.where(tf.math.is_inf(obs), 1.0, obs)
         features.append(log_normalize_fn(obs))
+        # pylint: disable=unexpected-keyword-arg
         return tf.concat(features, axis=-1)
 
       return tf.keras.layers.Lambda(use_def_density_processing_fn)

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -40,7 +40,8 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
       ir_path, tf_policy_path, default_reward, moving_average_reward)
   """
 
-  # TODO: refactor file_paths parameter to ensure correctness during construction
+  # TODO: refactor file_paths parameter to ensure correctness during
+  # construction
   def _compile_fn(
       self, file_paths: Tuple[str, str, str], tf_policy_path: str,
       reward_only: bool, cancellation_manager: Optional[

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module for collect data of regalloc-for-performance."""
 
 import base64

--- a/compiler_opt/rl/regalloc_network.py
+++ b/compiler_opt/rl/regalloc_network.py
@@ -162,6 +162,7 @@ class RegAllocNetwork(network.DistributionNetwork):
            network_state=(),
            training: bool = False,
            mask=None):
+    _ = mask
     state, network_state = self._encoder(
         observations,
         step_type=step_type,

--- a/compiler_opt/rl/regalloc_network.py
+++ b/compiler_opt/rl/regalloc_network.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Actor network for Register Allocation."""
 
 from typing import Optional, Sequence, Callable, Text, Any

--- a/compiler_opt/rl/regalloc_network.py
+++ b/compiler_opt/rl/regalloc_network.py
@@ -28,7 +28,7 @@ from tf_agents.utils import nest_utils
 class RegAllocEncodingNetwork(encoding_network.EncodingNetwork):
 
   def __init__(self, **kwargs):
-    super(RegAllocEncodingNetwork, self).__init__(**kwargs)
+    super().__init__(**kwargs)
     # remove the first layer (Flatten) in postprocessing_layers cause this will
     # flatten the B x T x 33 x dim to B x T x (33 x dim).
     self._postprocessing_layers = self._postprocessing_layers[1:]
@@ -38,7 +38,7 @@ class RegAllocProbProjectionNetwork(
     categorical_projection_network.CategoricalProjectionNetwork):
 
   def __init__(self, **kwargs):
-    super(RegAllocProbProjectionNetwork, self).__init__(**kwargs)
+    super().__init__(**kwargs)
     # shape after projection_layer: B x T x 33 x 1; then gets re-shaped to
     # B x T x 33.
     self._projection_layer = tf.keras.layers.Dense(
@@ -54,7 +54,7 @@ class RegAllocRNDEncodingNetwork(RegAllocEncodingNetwork):
 
   def __init__(self, **kwargs):
     pooling_layer = tf.keras.layers.GlobalMaxPool1D(data_format='channels_last')
-    super(RegAllocRNDEncodingNetwork, self).__init__(**kwargs)
+    super().__init__(**kwargs)
     # add a pooling layer at the end to to convert B x T x 33 x dim to
     # B x T x dim.
     self._postprocessing_layers.append(pooling_layer)
@@ -142,7 +142,7 @@ class RegAllocNetwork(network.DistributionNetwork):
         sample_spec=output_tensor_spec, logits_init_output_factor=0.1)
     output_spec = projection_network.output_spec
 
-    super(RegAllocNetwork, self).__init__(
+    super().__init__(
         input_tensor_spec=input_tensor_spec,
         state_spec=(),
         output_spec=output_spec,

--- a/compiler_opt/rl/regalloc_network_test.py
+++ b/compiler_opt/rl/regalloc_network_test.py
@@ -40,7 +40,7 @@ class RegAllocNetworkTest(tf.test.TestCase):
     time_step_spec, action_spec = config.get_regalloc_signature_spec()
     random_observation = tensor_spec.sample_spec_nest(
         time_step_spec, outer_dims=(2, 3))
-    super(RegAllocNetworkTest, self).setUp()
+    super().setUp()
     self._time_step_spec = time_step_spec
     self._action_spec = action_spec
     self._random_observation = random_observation

--- a/compiler_opt/rl/regalloc_network_test.py
+++ b/compiler_opt/rl/regalloc_network_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for tf_agents.networks.actor_distribution_network."""
 
 import tensorflow as tf

--- a/compiler_opt/rl/registry.py
+++ b/compiler_opt/rl/registry.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Compilation problem component model registry.
 
 This allows tools just get a ProblemConfiguration object encapsulating all
@@ -34,7 +33,6 @@ from compiler_opt.rl import problem_configuration
 # to trigger gin registration.
 import compiler_opt.rl.inlining  # pylint: disable=unused-import
 import compiler_opt.rl.regalloc  # pylint: disable=unused-import
-
 
 types = tfa.typing.types
 

--- a/compiler_opt/rl/train_bc.py
+++ b/compiler_opt/rl/train_bc.py
@@ -36,7 +36,8 @@ _ROOT_DIR = flags.DEFINE_string(
 _DATA_PATH = flags.DEFINE_multi_string(
     'data_path', [],
     'Path to TFRecord file(s) containing training data. Skip training and dump'
-    'an untrained model with random weights (for testing purpose) if unspecified.'
+    'an untrained model with random weights (for testing purpose) if '
+    'unspecified.'
 )
 _GIN_FILES = flags.DEFINE_multi_string(
     'gin_files', [], 'List of paths to gin configuration files.')

--- a/compiler_opt/rl/train_bc.py
+++ b/compiler_opt/rl/train_bc.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 r"""Train behavioral cloning policy for LLVM Inliner decision rule."""
 
 import os
@@ -64,10 +63,8 @@ def train_eval(agent_name=constant.AgentName.BEHAVIORAL_CLONE,
                                          preprocessing_layer_creator)
   llvm_trainer = trainer.Trainer(root_dir=root_dir, agent=tf_agent)
   policy_dict = {
-      'saved_policy':
-          tf_agent.policy,
-      'saved_collect_policy':
-          tf_agent.collect_policy,
+      'saved_policy': tf_agent.policy,
+      'saved_collect_policy': tf_agent.collect_policy,
   }
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 

--- a/compiler_opt/rl/train_bc.py
+++ b/compiler_opt/rl/train_bc.py
@@ -37,8 +37,7 @@ _DATA_PATH = flags.DEFINE_multi_string(
     'data_path', [],
     'Path to TFRecord file(s) containing training data. Skip training and dump'
     'an untrained model with random weights (for testing purpose) if '
-    'unspecified.'
-)
+    'unspecified.')
 _GIN_FILES = flags.DEFINE_multi_string(
     'gin_files', [], 'List of paths to gin configuration files.')
 _GIN_BINDINGS = flags.DEFINE_multi_string(

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -26,6 +26,7 @@ from absl import logging
 import gin
 import tensorflow as tf
 from tf_agents.system import system_multiprocessing as multiprocessing
+from typing import List
 
 from compiler_opt.rl import agent_creators
 from compiler_opt.rl import compilation_runner
@@ -97,7 +98,9 @@ def train_eval(agent_name=constant.AgentName.PPO,
   }
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 
-  with open(os.path.join(FLAGS.data_path, 'module_paths'), 'r') as f:
+  with open(
+      os.path.join(FLAGS.data_path, 'module_paths'), 'r',
+      encoding='utf-8') as f:
     module_paths = [
         os.path.join(FLAGS.data_path, name.rstrip('\n')) for name in f
     ]
@@ -118,8 +121,8 @@ def train_eval(agent_name=constant.AgentName.PPO,
       batch_size=batch_size,
       train_sequence_length=train_sequence_length)
 
-  sequence_example_iterator_fn = (
-      lambda seq_ex: iter(dataset_fn(seq_ex).repeat()))
+  def sequence_example_iterator_fn(seq_ex: List[str]):
+    return iter(dataset_fn(seq_ex).repeat())
 
   reward_stat_map = collections.defaultdict(lambda: None)
   reward_stat_map_path = os.path.join(root_dir, 'reward_stat_map')

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 r"""Train and Eval LLVM Inliner decision rule with local_data_collector."""
 
 import collections

--- a/compiler_opt/rl/trainer.py
+++ b/compiler_opt/rl/trainer.py
@@ -174,6 +174,8 @@ class Trainer(object):
   def train(self, dataset_iter, monitor_dict, num_iterations):
     """Trains policy with data from dataset_iter for num_iterations steps."""
     self._reset_metrics()
+    # context management is implemented in decorator
+    # pylint: disable=not-context-manager
     with tf.summary.record_if(
         lambda: tf.math.equal(self._global_step % self._summary_interval, 0)):
       for _ in range(num_iterations):

--- a/compiler_opt/rl/trainer.py
+++ b/compiler_opt/rl/trainer.py
@@ -184,8 +184,8 @@ class Trainer(object):
           experience = next(dataset_iter)
         except StopIteration:
           logging.warning(
-              'Warning: skip training because do not have enough data to fill in a batch, consider increase data or reduce batch size.'
-          )
+              ('Warning: skip training because do not have enough data to fill '
+               'in a batch, consider increase data or reduce batch size.'))
           break
 
         # random network distillation for intrinsic reward generation

--- a/compiler_opt/rl/trainer.py
+++ b/compiler_opt/rl/trainer.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """LLVM Policy Trainer."""
 
 import time

--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylint: disable=protected-access
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.rl.trainer."""
 
 from absl.testing.absltest import mock
@@ -30,11 +29,12 @@ def _create_test_data(batch_size, sequence_length):
   test_trajectory = trajectory.Trajectory(
       step_type=tf.fill([batch_size, sequence_length], 1),
       observation={
-          'inlining_default': tf.fill(
-              [batch_size, sequence_length], tf.constant(10, dtype=tf.int64))
+          'inlining_default':
+              tf.fill([batch_size, sequence_length],
+                      tf.constant(10, dtype=tf.int64))
       },
-      action=tf.fill(
-          [batch_size, sequence_length], tf.constant(1, dtype=tf.int64)),
+      action=tf.fill([batch_size, sequence_length],
+                     tf.constant(1, dtype=tf.int64)),
       policy_info=(),
       next_step_type=tf.fill([batch_size, sequence_length], 1),
       reward=tf.fill([batch_size, sequence_length], 2.0),
@@ -149,6 +149,7 @@ class TrainerTest(tf.test.TestCase):
     action_outputs = test_trainer._agent.policy.action(random_time_step,
                                                        action_outputs.state)
     self.assertAllEqual([inference_batch_size], action_outputs.action.shape)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -69,7 +69,7 @@ class TrainerTest(tf.test.TestCase):
         preprocessing_layers={
             'inlining_default': tf.keras.layers.Lambda(lambda x: x)
         })
-    super(TrainerTest, self).setUp()
+    super().setUp()
 
   def test_trainer_initialization(self):
     test_agent = behavioral_cloning_agent.BehavioralCloningAgent(

--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 """Tests for compiler_opt.rl.trainer."""
 
-from absl.testing.absltest import mock
 import tensorflow as tf
 from tf_agents.agents.behavioral_cloning import behavioral_cloning_agent
 from tf_agents.networks import q_rnn_network
 from tf_agents.specs import tensor_spec
 from tf_agents.trajectories import time_step
 from tf_agents.trajectories import trajectory
+from unittest import mock
 
 from compiler_opt.rl import trainer
 

--- a/compiler_opt/tools/benchmark_report.py
+++ b/compiler_opt/tools/benchmark_report.py
@@ -38,7 +38,7 @@ ABComparison = Dict[str, Dict[str, Tuple[float, float, float]]]
 
 
 def _geomean(data: List[float]):
-  return math.exp(sum([math.log(x) for x in data]) / len(data))
+  return math.exp(sum(math.log(x) for x in data) / len(data))
 
 
 def _stdev(data: List[float]):

--- a/compiler_opt/tools/benchmark_report.py
+++ b/compiler_opt/tools/benchmark_report.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Analysis for benchmark results.json."""
 
 import collections

--- a/compiler_opt/tools/benchmark_report_converter.py
+++ b/compiler_opt/tools/benchmark_report_converter.py
@@ -70,7 +70,7 @@ def main(argv: Sequence[str]) -> None:
       summary = comparison.summarize()
   with tf.io.gfile.GFile(FLAGS.output, 'w+') as o:
     co = csv.writer(o)
-    for bm in summary:
+    for bm in summary.items():
       for c in summary[bm]:
         co.writerow([bm, c] + list(summary[bm][c]))
 

--- a/compiler_opt/tools/benchmark_report_converter.py
+++ b/compiler_opt/tools/benchmark_report_converter.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 r"""Convert benchmark results.json to csv.
 
 To run:

--- a/compiler_opt/tools/benchmark_report_test.py
+++ b/compiler_opt/tools/benchmark_report_test.py
@@ -12,13 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.tools.benchmark_report_converter."""
 
 from absl.testing import absltest
 
 from compiler_opt.tools import benchmark_report
-
 
 base_data = {
     'benchmarks': [

--- a/compiler_opt/tools/combine_training_corpus.py
+++ b/compiler_opt/tools/combine_training_corpus.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 r"""Combine multiple training corpus into a single training corpus.
 
 Usage: we'd like to combine training corpus corpus1 and corpus2 into

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -272,7 +272,7 @@ def main(argv):
           f.write(path + '\n')
 
     logging.info('Converted %d files out of %d',
-                len(objs) - relative_output_paths.count(None), len(objs))
+                 len(objs) - relative_output_paths.count(None), len(objs))
 
 
 if __name__ == '__main__':

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Extract IR for training.
 
 Extract IR for training, either from a compile_commands.json file produced by

--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylint: disable=protected-access
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for compiler_opt.tools.extract_ir."""
 
 from absl.testing import absltest

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Generate initial training data from the behavior of the current heuristic."""
 
 import contextlib
@@ -65,7 +64,6 @@ _GIN_FILES = flags.DEFINE_multi_string(
 _GIN_BINDINGS = flags.DEFINE_multi_string(
     'gin_bindings', [],
     'Gin bindings to override the values set in the config files.')
-
 
 ResultsQueueEntry = Optional[Tuple[str, List[str],
                                    Dict[str, compilation_runner.RewardStat]]]

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -129,7 +129,9 @@ def main(_):
   runner = problem_config.get_runner(moving_average_decay_rate=0)
   assert runner
 
-  with open(os.path.join(_DATA_PATH.value, 'module_paths'), 'r') as f:
+  with open(
+      os.path.join(_DATA_PATH.value, 'module_paths'), 'r',
+      encoding='utf-8') as f:
     module_paths = [
         os.path.join(_DATA_PATH.value, name.rstrip('\n')) for name in f
     ]
@@ -151,7 +153,7 @@ def main(_):
   sizes_and_paths.sort(reverse=True)
   sorted_module_paths = [p for _, p in sizes_and_paths]
   module_specs = [
-      tuple([p + suffix for suffix in file_suffix]) for p in sorted_module_paths
+      tuple(p + suffix for suffix in file_suffix) for p in sorted_module_paths
   ]
 
   worker_count = (
@@ -209,13 +211,13 @@ def main(_):
             tfrecord_writer.write(r)
         if performance_writer:
           for key, value in reward_stat.items():
-            performance_writer.write('%s,%s,%f,%f\n' %
-                                     (module_name, key, value.default_reward,
-                                      value.moving_average_reward))
+            performance_writer.write(
+                (f'{module_name},{key},{value.default_reward},'
+                 f'{value.moving_average_reward}\n'))
 
-      print('%d of %d modules succeeded, and %d trainining examples written' %
-            (total_successful_examples, len(module_specs),
-             total_training_examples))
+      print((f'{total_successful_examples} of {len(module_specs)} modules '
+             f'succeeded, and {total_training_examples} trainining examples '
+             'written'))
       for p in processes:
         p.join()
 

--- a/compiler_opt/tools/sparse_bucket_generator.py
+++ b/compiler_opt/tools/sparse_bucket_generator.py
@@ -116,10 +116,10 @@ def _generate_vocab(feature_values_arrays, feature_name):
       np.shape(feature_values)[0] * FLAGS.sampling_fraction)
   values = np.random.choice(feature_values, sample_length, replace=False)
   bin_edges = np.quantile(values, np.linspace(0, 1, FLAGS.num_buckets))
-  filename = os.path.join(FLAGS.output_dir, '{}.buckets'.format(feature_name))
-  with open(filename, 'w') as f:
+  filename = os.path.join(FLAGS.output_dir, f'{feature_name}.buckets')
+  with open(filename, 'w', encoding='utf-8') as f:
     for edge in bin_edges:
-      f.write('{}\n'.format(edge))
+      f.write(f'{edge}\n')
 
 
 def main(_) -> None:

--- a/compiler_opt/tools/sparse_bucket_generator.py
+++ b/compiler_opt/tools/sparse_bucket_generator.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """OSS-compatible pipeline to generate sparse buckets.
 
 Generate numerical features' X (1000) quantile based on their distributions
@@ -31,16 +30,15 @@ from absl import logging
 import numpy as np
 import tensorflow as tf
 
-
 flags.DEFINE_string('input', None,
                     'Path to input file containing tf record datasets.')
 flags.DEFINE_string('output_dir', None,
                     'Path to output directory to store quantiles per feature.')
 flags.DEFINE_float('sampling_fraction', 1.0,
                    'Fraction to downsample input data.', 0.0, 1.0)
-flags.DEFINE_integer('parallelism', None,
-                     'Number of parallel processes to spawn.'
-                     'Each process does vocab generation for each feature.', 1)
+flags.DEFINE_integer(
+    'parallelism', None, 'Number of parallel processes to spawn.'
+    'Each process does vocab generation for each feature.', 1)
 flags.DEFINE_integer('num_buckets', 1000,
                      'Number of quantiles to bucketize feature values into.')
 
@@ -64,17 +62,17 @@ def _get_feature_info(
     feature = feature_list.feature[0]
     kind = feature.WhichOneof('kind')
     if kind == 'float_list':
-      sequence_features[key] = tf.io.RaggedFeature(partitions=(),
-                                                   dtype=tf.float32)
+      sequence_features[key] = tf.io.RaggedFeature(
+          partitions=(), dtype=tf.float32)
     elif kind == 'int64_list':
-      sequence_features[key] = tf.io.RaggedFeature(partitions=(),
-                                                   dtype=tf.int64)
+      sequence_features[key] = tf.io.RaggedFeature(
+          partitions=(), dtype=tf.int64)
   return sequence_features
 
 
 def create_tfrecord_parser_fn(
-    sequence_features:
-    Dict[str, tf.io.RaggedFeature]) -> Callable[[str], List[tf.Tensor]]:
+    sequence_features: Dict[str, tf.io.RaggedFeature]
+) -> Callable[[str], List[tf.Tensor]]:
   """Create a parser function for reading serialized tf.data.TFRecordDataset.
 
   Args:
@@ -118,8 +116,7 @@ def _generate_vocab(feature_values_arrays, feature_name):
       np.shape(feature_values)[0] * FLAGS.sampling_fraction)
   values = np.random.choice(feature_values, sample_length, replace=False)
   bin_edges = np.quantile(values, np.linspace(0, 1, FLAGS.num_buckets))
-  filename = os.path.join(FLAGS.output_dir,
-                          '{}.buckets'.format(feature_name))
+  filename = os.path.join(FLAGS.output_dir, '{}.buckets'.format(feature_name))
   with open(filename, 'w') as f:
     for edge in bin_edges:
       f.write('{}\n'.format(edge))
@@ -158,8 +155,10 @@ def main(_) -> None:
   with mp.Pool(FLAGS.parallelism) as pool:
     feature_names = list(sorted(sequence_features))
     for i, feature_values_arrays in enumerate(data_list):
-      pool.apply_async(_generate_vocab,
-                       (feature_values_arrays, feature_names[i],))
+      pool.apply_async(_generate_vocab, (
+          feature_values_arrays,
+          feature_names[i],
+      ))
     pool.close()
     pool.join()
 


### PR DESCRIPTION
This patch enables linting using pylint and type checking using pytype. Auto-formatting support is provided for `yapf`. Settings are available (i.e. a `.style.yapf` file and a `.pylintrc`, the latter being used by the CI)

The CI is updated to ensure type checking and linting pass. Tests are run even if lint fails (because it can be helpful to separate actual bugs from stylistic issues)

The rest of the patch is changes to files to ensure conformance, see the commit history.