### PR TITLE
Fixed regalloc behavioral cloning

### DIFF
--- a/compiler_opt/rl/regalloc/gin_configs/behavioral_cloning_nn_agent.gin
+++ b/compiler_opt/rl/regalloc/gin_configs/behavioral_cloning_nn_agent.gin
@@ -14,6 +14,7 @@ train_eval.batch_size=64
 train_eval.train_sequence_length=1
 
 regalloc.config.get_observation_processing_layer_creator.quantile_file_dir='compiler_opt/rl/regalloc/vocab'
+regalloc.config.get_observation_processing_layer_creator.with_sqrt = False
 regalloc.config.get_observation_processing_layer_creator.with_z_score_normalization = False
 
 create_agent.policy_network = @regalloc_network.RegAllocNetwork


### PR DESCRIPTION
This patch adds the flag `regalloc.config.get_observation_processing_layer_creator.with_sqrt = False` to the regalloc behavioral cloning config. Without this flag explicitly being set to false, the models created by the behavioral cloning script for the regalloc model are not compatible with the local training script.