### PR TITLE
Refactored regalloc gin configs

### DIFF
--- a/compiler_opt/rl/regalloc/gin_configs/behavioral_cloning_nn_agent.gin
+++ b/compiler_opt/rl/regalloc/gin_configs/behavioral_cloning_nn_agent.gin
@@ -7,22 +7,14 @@ import tf_agents.agents.behavioral_cloning.behavioral_cloning_agent
 import tf_agents.networks.actor_distribution_network
 
 include 'compiler_opt/rl/regalloc/gin_configs/common.gin'
+include 'compiler_opt/rl/regalloc/gin_configs/network.gin'
 
 train_eval.agent_name=%constant.AgentName.BEHAVIORAL_CLONE
 train_eval.num_iterations=10000
 train_eval.batch_size=64
 train_eval.train_sequence_length=1
 
-regalloc.config.get_observation_processing_layer_creator.quantile_file_dir='compiler_opt/rl/regalloc/vocab'
-regalloc.config.get_observation_processing_layer_creator.with_sqrt = False
-regalloc.config.get_observation_processing_layer_creator.with_z_score_normalization = False
-
-create_agent.policy_network = @regalloc_network.RegAllocNetwork
-
-RegAllocNetwork.preprocessing_combiner=@tf.keras.layers.Concatenate()
-RegAllocNetwork.fc_layer_params=(80, 40)
-RegAllocNetwork.dropout_layer_params=(0.2, 0.2)
-RegAllocNetwork.activation_fn=@tf.keras.activations.relu
+RegAllocNetwork.dropout_layer_params = (0.2, 0.2)
 
 tf.train.AdamOptimizer.learning_rate = 0.001
 tf.train.AdamOptimizer.epsilon = 0.0003125

--- a/compiler_opt/rl/regalloc/gin_configs/network.gin
+++ b/compiler_opt/rl/regalloc/gin_configs/network.gin
@@ -1,0 +1,14 @@
+import compiler_opt.rl.gin_external_configurables
+import compiler_opt.rl.regalloc.config
+import compiler_opt.rl.regalloc_network
+
+regalloc.config.get_observation_processing_layer_creator.quantile_file_dir='compiler_opt/rl/regalloc/vocab'
+regalloc.config.get_observation_processing_layer_creator.with_sqrt = False
+regalloc.config.get_observation_processing_layer_creator.with_z_score_normalization = False
+
+create_agent.policy_network = @regalloc_network.RegAllocNetwork
+
+RegAllocNetwork.preprocessing_combiner=@tf.keras.layers.Concatenate()
+RegAllocNetwork.fc_layer_params=(80, 40)
+RegAllocNetwork.dropout_layer_params=None
+RegAllocNetwork.activation_fn=@tf.keras.activations.relu

--- a/compiler_opt/rl/regalloc/gin_configs/ppo_nn_agent.gin
+++ b/compiler_opt/rl/regalloc/gin_configs/ppo_nn_agent.gin
@@ -8,6 +8,7 @@ import tf_agents.agents.ppo.ppo_agent
 import tf_agents.networks.actor_distribution_network
 
 include 'compiler_opt/rl/regalloc/gin_configs/common.gin'
+include 'compiler_opt/rl/regalloc/gin_configs/network.gin'
 
 train_eval.agent_name=%constant.AgentName.PPO
 train_eval.warmstart_policy_dir=''
@@ -32,16 +33,7 @@ RandomNetworkDistillation.fc_layer_params = [32, 128]
 RandomNetworkDistillation.initial_intrinsic_reward_scale = 1.0
 RandomNetworkDistillation.half_decay_steps = 10000
 
-regalloc.config.get_observation_processing_layer_creator.quantile_file_dir='compiler_opt/rl/regalloc/vocab'
-regalloc.config.get_observation_processing_layer_creator.with_sqrt = False
-regalloc.config.get_observation_processing_layer_creator.with_z_score_normalization = False
-
 create_agent.policy_network = @regalloc_network.RegAllocNetwork
-
-RegAllocNetwork.preprocessing_combiner=@tf.keras.layers.Concatenate()
-RegAllocNetwork.fc_layer_params=(80, 40)
-RegAllocNetwork.dropout_layer_params=None
-RegAllocNetwork.activation_fn=@tf.keras.activations.relu
 
 ConstantValueNetwork.constant_output_val=0
 


### PR DESCRIPTION
This should help mitigate issues in the future like the one fixed in #27 as it refactors the gin configs for regalloc so that the common network parameters are stored in their own file and imported into the behavioral cloning and agent configs. Reducing code duplication and having a central place to make changes to the model should allow for easier changes and changes that are more likely to be correct. The same thing could probably also be done with the inlining config although with some differences due to the fact that there are many more configs (multiple common network configs need to be refactored out), and the standard behavioral cloning and agent configs use different network classes. Could be done with gin macros, but it doesn't refactor as nicely as the regalloc configs.