### PR TITLE
Only generate/use vocab when needed

### DIFF
--- a/compiler_opt/rl/inlining/__init__.py
+++ b/compiler_opt/rl/inlining/__init__.py
@@ -33,3 +33,6 @@ class InliningConfig(problem_configuration.ProblemConfiguration):
 
   def get_preprocessing_layer_creator(self):
     return config.get_observation_processing_layer_creator()
+
+  def get_nonnormalized_features(self):
+    return config.get_nonnormalized_features()

--- a/compiler_opt/rl/inlining/config.py
+++ b/compiler_opt/rl/inlining/config.py
@@ -97,3 +97,7 @@ def get_observation_processing_layer_creator(quantile_file_dir=None,
                                      with_z_score_normalization, eps))
 
   return observation_processing_layer
+
+def get_nonnormalized_features():
+  return ['reward', 'inlining_default', 'inlining_decision']
+

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -93,10 +93,12 @@ class ProblemConfiguration(metaclass=abc.ABCMeta):
       self) -> Callable[[types.TensorSpec], tf.keras.layers.Layer]:
     raise NotImplementedError
 
+  def get_nonnormalized_features(self) -> Iterable[str]:
+    return []
+
   @abc.abstractmethod
   def get_runner_type(self) -> 'type[compilation_runner.CompilationRunner]':
     raise NotImplementedError
-
 
 def is_thinlto(module_paths: Iterable[str]) -> bool:
   return tf.io.gfile.exists(next(iter(module_paths)) + '.thinlto.bc')

--- a/compiler_opt/rl/regalloc/__init__.py
+++ b/compiler_opt/rl/regalloc/__init__.py
@@ -33,3 +33,6 @@ class RegallocEvictionConfig(problem_configuration.ProblemConfiguration):
 
   def get_preprocessing_layer_creator(self):
     return config.get_observation_processing_layer_creator()
+
+  def get_nonnormalized_features(self):
+    return config.get_nonnormalized_features()

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -29,6 +29,13 @@ First and foremost, **you must regenerate the vocabulary** - technically you
 just need a vocab file for the new feature, but it's simpler to regenerate it
 all. See the [demo section](demo/demo.md#collect-trace-and-generate-vocab)
 
+**Note:** You only need to regenerate the vocabulary if the feature is going
+to be normalized by a preprocessing layer for your model. If your feature does
+not need to get put through a lambda normalization preprocessing layer, make sure
+to regenerate the vocabulary and that your feature is added to the list
+returned by `get_nonnormalized_features()` in `config.py`. In either case,
+it is still quite simple and fast to just call the vocab generation again.
+
 After that, retrain from [scratch](demo/demo.md#train-a-new-model).
 
 ## Notes

--- a/docs/demo/demo.md
+++ b/docs/demo/demo.md
@@ -266,6 +266,7 @@ in the trace changes.
 rm -rf $DEFAULT_VOCAB &&
   PYTHONPATH=$PYTHONPATH:. python3 \
     compiler_opt/tools/sparse_bucket_generator.py \
+    --gin_files=compiler_opt/rl/inlining/gin_configs/common.gin \
     --input=$DEFAULT_TRACE \
     --output_dir=$DEFAULT_VOCAB
 ```


### PR DESCRIPTION
Currently, the vocab generator generates quantile buckets for all the different features regardless of whether or not they are relevant. This patch adds an option into the problem config so that features that don't require quantile buckets won't have them generated. This saves on some performance during vocab generation and prevents having to load a couple things during the preprocessing layer generation (although the latter difference is extremely insignificant). In addition to the config option, this patch also ties the config option into the vocab generator and both current problem configs. The major advantage of this feature is that it skips vocab generation for extremely large features (eg the new instruction based features for the regalloc model) that don't need vocab generated and use up a massive amount of memory (hundreds of gigabytes) during vocab generation for no real reason. I have already validated the changes against both the inlining config (based on the demo), and the regalloc config (based on [these](https://github.com/boomanaiden154/gsoc2022-notes/blob/master/june/3/regalloc-model-training.md) instructions).