### PR TITLE
[infra] Expose the runner class rather than a factory method.

### DIFF
--- a/compiler_opt/rl/inlining/__init__.py
+++ b/compiler_opt/rl/inlining/__init__.py
@@ -25,8 +25,8 @@ from compiler_opt.rl.inlining import inlining_runner
 class InliningConfig(problem_configuration.ProblemConfiguration):
   """Expose the regalloc eviction components."""
 
-  def get_runner(self, *args, **kwargs):
-    return inlining_runner.InliningRunner(*args, **kwargs)
+  def get_runner_type(self):
+    return inlining_runner.InliningRunner
 
   def get_signature_spec(self):
     return config.get_inlining_signature_spec()

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -92,7 +92,7 @@ class ProblemConfiguration(metaclass=abc.ABCMeta):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def get_runner(self, *args, **kwargs) -> compilation_runner.CompilationRunner:
+  def get_runner_type(self) -> type[compilation_runner.CompilationRunner]:
     raise NotImplementedError
 
 

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -73,6 +73,8 @@ from typing import Callable, Iterable, Tuple
 import tensorflow as tf
 import tf_agents as tfa
 
+# used for type annotation in a string (for 3.8 compat)
+# pylint: disable=unused-import
 from compiler_opt.rl import compilation_runner
 
 types = tfa.typing.types

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -92,7 +92,7 @@ class ProblemConfiguration(metaclass=abc.ABCMeta):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def get_runner_type(self) -> type[compilation_runner.CompilationRunner]:
+  def get_runner_type(self) -> 'type[compilation_runner.CompilationRunner]':
     raise NotImplementedError
 
 

--- a/compiler_opt/rl/regalloc/__init__.py
+++ b/compiler_opt/rl/regalloc/__init__.py
@@ -25,8 +25,8 @@ from compiler_opt.rl.regalloc import regalloc_runner
 class RegallocEvictionConfig(problem_configuration.ProblemConfiguration):
   """Expose the regalloc eviction configuration."""
 
-  def get_runner(self, *args, **kwargs):
-    return regalloc_runner.RegAllocRunner(*args, **kwargs)
+  def get_runner_type(self):
+    return regalloc_runner.RegAllocRunner
 
   def get_signature_spec(self):
     return config.get_regalloc_signature_spec()

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -111,7 +111,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
       file_paths = [(path + '.bc', path + '.cmd', path + '.thinlto.bc')
                     for path in module_paths]
 
-  runner = problem_config.get_runner(
+  runner = problem_config.get_runner_type()(
       moving_average_decay_rate=moving_average_decay_rate)
 
   dataset_fn = data_reader.create_sequence_example_dataset_fn(

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -126,7 +126,7 @@ def main(_):
   logging.info(gin.config_str())
 
   problem_config = registry.get_configuration()
-  runner = problem_config.get_runner(moving_average_decay_rate=0)
+  runner = problem_config.get_runner_type(moving_average_decay_rate=0)
   assert runner
 
   with open(

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -126,7 +126,7 @@ def main(_):
   logging.info(gin.config_str())
 
   problem_config = registry.get_configuration()
-  runner = problem_config.get_runner_type(moving_average_decay_rate=0)
+  runner = problem_config.get_runner_type()(moving_average_decay_rate=0)
   assert runner
 
   with open(


### PR DESCRIPTION
This simplifies support for compute distribution middleware where the
mechanism of distributing work is via class decorations. This also
simplifies handling gin bindings because the distribution code on our
end can fetch gin bindings before sending the work remotely.

(Issue #31)