### PR TITLE
Extend license checking to .sh files

### DIFF
--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/bin/bash
 
 # Script to configure GCE instance to run LLVM ml-driven optimization build bots.
 

--- a/check-license.sh
+++ b/check-license.sh
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
 exitcode=0
@@ -10,4 +24,15 @@ do
     exitcode=1
   fi
 done
+
+for fname in `find . -name "*.sh"`; 
+do
+  diff -q <(head -13 $fname) <(tail -13 license-header.txt) > /dev/null
+  if [ $? -ne 0 ]
+  then
+    echo "$fname does not have license header. Please copy and paste ./license-header.txt"
+    exitcode=1
+  fi
+done
+
 exit ${exitcode}


### PR DESCRIPTION
the only difference is that they don't need to check
encoding.