### PR TITLE
Added dockerfile with base dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+COPY . /ml-compiler-opt
+RUN python3 -m pip install -r /ml-compiler-opt/requirements.txt
+VOLUME /external
+


### PR DESCRIPTION
@petrhosek Here are the base dependencies for `ml-compiler-opt` based on the buildbot dependencies. I'm assuming you're just using all of these dependencies for building LLVM/clang? This is what I guess would be considered the "official" dependency setup for LLVM, but depending upon what you need, I can change it up. Just let me know.