### PR TITLE
Refactor file_paths into ModuleSpec 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vscode
+.idea

--- a/compiler_opt/distributed/local/local_worker_manager.py
+++ b/compiler_opt/distributed/local/local_worker_manager.py
@@ -127,9 +127,11 @@ def _make_stub(cls: 'type[Worker]', *args, **kwargs):
 
       # thread drainig the receive queue
       self._pump = threading.Thread(target=self._msg_pump)
+
       def observer():
         self._process.join()
         self._receive.put(None)
+
       self._observer = threading.Thread(target=observer)
 
       # atomic control to _msgid

--- a/compiler_opt/distributed/local/local_worker_manager_test.py
+++ b/compiler_opt/distributed/local/local_worker_manager_test.py
@@ -80,7 +80,6 @@ class LocalWorkerManagerTest(absltest.TestCase):
         # worker hosting process will crash.
         pool[0].method().result()
 
-
   def test_worker_crash_while_waiting(self):
 
     class Job(Worker):

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -26,6 +26,7 @@ from absl import flags
 import tensorflow as tf
 
 from compiler_opt.rl import constant
+from compiler_opt.rl import corpus
 
 _COMPILATION_TIMEOUT = flags.DEFINE_integer(
     'compilation_timeout', 60,
@@ -331,7 +332,7 @@ class CompilationRunner:
 
   def collect_data(
       self,
-      file_paths: Tuple[str, ...],
+      module_spec: corpus.ModuleSpec,
       tf_policy_path: str,
       reward_stat: Optional[Dict[str, RewardStat]],
       cancellation_token: Optional[ProcessCancellationToken] = None
@@ -339,7 +340,7 @@ class CompilationRunner:
     """Collect data for the given IR file and policy.
 
     Args:
-      file_paths: path to files needed for inlining, Tuple of (.bc, .cmd).
+      module_spec: a ModuleSpec.
       tf_policy_path: path to the tensorflow policy.
       reward_stat: reward stat of this module, None if unknown.
       cancellation_token: a CancellationToken through which workers may be
@@ -359,7 +360,7 @@ class CompilationRunner:
 
     if reward_stat is None:
       default_result = self._compile_fn(
-          file_paths,
+          module_spec,
           tf_policy_path='',
           reward_only=bool(tf_policy_path),
           cancellation_manager=cancellation_manager)
@@ -369,7 +370,7 @@ class CompilationRunner:
 
     if tf_policy_path:
       policy_result = self._compile_fn(
-          file_paths,
+          module_spec,
           tf_policy_path,
           reward_only=False,
           cancellation_manager=cancellation_manager)
@@ -385,7 +386,7 @@ class CompilationRunner:
       if k not in reward_stat:
         raise ValueError(
             (f'Example {k} does not exist under default policy for '
-             'module {file_paths[0]}'))
+             f'module {module_spec.name}'))
       default_reward = reward_stat[k].default_reward
       moving_average_reward = reward_stat[k].moving_average_reward
       sequence_example = _overwrite_trajectory_reward(
@@ -407,13 +408,14 @@ class CompilationRunner:
         keys=keys)
 
   def _compile_fn(
-      self, file_paths: Tuple[str, ...], tf_policy_path: str, reward_only: bool,
+      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      reward_only: bool,
       cancellation_manager: Optional[WorkerCancellationManager]
   ) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Compiles for the given IR file under the given policy.
 
     Args:
-      file_paths: path to files needed for compilation.
+      module_spec: a ModuleSpec.
       tf_policy_path: path to TF policy directory on local disk.
       reward_only: whether only return reward.
       cancellation_manager: a WorkerCancellationManager to handle early

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -216,43 +216,6 @@ class CompilationRunnerTest(tf.test.TestCase):
           reward_stat=None)
     self.assertEqual(1, mock_compile_fn.call_count)
 
-  def test_command_line_file(self):
-    data = ['-cc1', '-foo', '-bar=baz']
-    argfile = self.create_tempfile(content='\0'.join(data))
-    self.assertEqual(
-        compilation_runner.get_command_line_for_bundle(argfile.full_path,
-                                                       'my_file.bc'),
-        ['-cc1', '-foo', '-bar=baz', '-x', 'ir', 'my_file.bc'])
-    self.assertEqual(
-        compilation_runner.get_command_line_for_bundle(argfile.full_path,
-                                                       'my_file.bc',
-                                                       'the_index.bc'),
-        [
-            '-cc1', '-foo', '-bar=baz', '-x', 'ir', 'my_file.bc',
-            '-fthinlto-index=the_index.bc'
-        ])
-
-  def test_command_line_correction(self):
-    delete_compilation_flags = ('-split-dwarf-file', '-split-dwarf-output',
-                                '-fthinlto-index', '-fprofile-sample-use',
-                                '-fprofile-remapping-file')
-    data = [
-        '-cc1', '-fthinlto-index=bad', '-split-dwarf-file', '/tmp/foo.dwo',
-        '-split-dwarf-output', 'somepath/some.dwo'
-    ]
-    argfile = self.create_tempfile(content='\0'.join(data))
-    self.assertEqual(
-        compilation_runner.get_command_line_for_bundle(
-            argfile.full_path, 'hi.bc', delete_flags=delete_compilation_flags),
-        ['-cc1', '-x', 'ir', 'hi.bc'])
-    self.assertEqual(
-        compilation_runner.get_command_line_for_bundle(
-            argfile.full_path,
-            'hi.bc',
-            'index.bc',
-            delete_flags=delete_compilation_flags),
-        ['-cc1', '-x', 'ir', 'hi.bc', '-fthinlto-index=index.bc'])
-
   def test_start_subprocess_output(self):
     ct = compilation_runner.WorkerCancellationManager()
     output = compilation_runner.start_cancellable_process(

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -28,6 +28,7 @@ from google.protobuf import text_format  # pytype: disable=pyi-error
 
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import constant
+from compiler_opt.rl import corpus
 
 _DEFAULT_FEATURE_VALUE = 12
 _POLICY_FEATURE_VALUE = 34
@@ -107,7 +108,8 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'),
+        module_spec=corpus.ModuleSpec(
+            exec_cmd=('-O2',), extra_opts={}, name='dummy'),
         tf_policy_path='policy_path',
         reward_stat=None)
     self.assertEqual(2, mock_compile_fn.call_count)
@@ -138,7 +140,10 @@ class CompilationRunnerTest(tf.test.TestCase):
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'), tf_policy_path='', reward_stat=None)
+        module_spec=corpus.ModuleSpec(
+            exec_cmd=('-O2',), extra_opts={}, name='dummy'),
+        tf_policy_path='',
+        reward_stat=None)
     # One call when we ask for the default policy, because it can provide both
     # trace and default size.
     self.assertEqual(1, mock_compile_fn.call_count)
@@ -167,7 +172,8 @@ class CompilationRunnerTest(tf.test.TestCase):
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'),
+        module_spec=corpus.ModuleSpec(
+            exec_cmd=('-O2',), extra_opts={}, name='dummy'),
         tf_policy_path='policy_path',
         reward_stat={
             'default':
@@ -204,7 +210,8 @@ class CompilationRunnerTest(tf.test.TestCase):
 
     with self.assertRaisesRegex(subprocess.CalledProcessError, 'error'):
       _ = runner.collect_data(
-          file_paths=('bc', 'cmd'),
+          module_spec=corpus.ModuleSpec(
+              exec_cmd=('-O2',), extra_opts={}, name='dummy'),
           tf_policy_path='policy_path',
           reward_stat=None)
     self.assertEqual(1, mock_compile_fn.call_count)

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -14,8 +14,12 @@
 # limitations under the License.
 """ModuleSpec definition and utility command line parsing functions."""
 
+from absl import logging
 from dataclasses import dataclass
-from typing import Tuple
+from typing import List, Dict, Iterable, Tuple, Optional
+import json
+import os
+import tensorflow as tf
 
 
 @dataclass(frozen=True)
@@ -25,3 +29,152 @@ class ModuleSpec:
   exec_cmd: Tuple[str, ...]
   extra_opts: dict[str, Tuple[str, ...]]
   name: str
+
+  def cmd(self, add_flags: List[Tuple[str, ...]] = None) -> List[str]:
+    """Retrieves the compiler execution options,
+    optionally adding configurable options.
+    """
+    ret_cmd: List[str] = list(self.exec_cmd)
+    if add_flags is None:
+      return ret_cmd
+
+    for opt in add_flags:
+      if len(opt) == 0 or len(opt) > 2:
+        logging.error('Additional option given of invalid length %d', len(opt))
+        raise ValueError
+      if len(opt) == 2:
+        if opt[0] == '-mllvm':
+          format_strs = self.extra_opts['mllvm']
+        else:
+          logging.error(
+              'Additional option of length 2 doesn\'t start with -mllvm')
+          raise ValueError
+      else:
+        format_strs = self.extra_opts['std']
+      ret_cmd += [s.format(opt=opt[-1]) for s in format_strs]
+    return ret_cmd
+
+
+def read(data_path: str, additional_flags: Tuple[str, ...],
+         delete_flags: Tuple[str, ...]) -> List[ModuleSpec]:
+  module_paths: List[str] = _load_module_paths(data_path)
+
+  is_thinlto: bool = _has_thinlto_index(module_paths)
+  has_cmd: bool = _has_cmd(module_paths)
+
+  # TODO: (b/233935329) Per-corpus *fdo profile paths can be read into
+  # {additional|delete}_flags here
+  meta = _load_metadata(os.path.join(data_path, 'metadata.json'))
+
+  extra_options = {  # In preparation for allowing -Wl,-flags
+      'mllvm': ('-mllvm', '{opt:s}'),
+      'std': ('{opt:s}',)
+  }
+
+  module_specs: List[ModuleSpec] = []
+
+  # Future: cmd_override could have per-module overrides if needed
+  if 'global_command_override' in meta:
+    cmd_override = tuple(meta['global_command_override'])
+    if len(additional_flags) > 0:
+      logging.warning("Additional flags are specified together with override.")
+    if len(delete_flags) > 0:
+      logging.warning("Delete flags are specified together with override.")
+  else:
+    cmd_override = None
+
+  # This takes ~7s for 30k modules
+  for module_path in module_paths:
+    exec_cmd = _load_and_parse_command(
+        cmd_file=(module_path + '.cmd') if has_cmd else None,
+        ir_file=module_path + '.bc',
+        thinlto_file=(module_path + '.thinlto.bc') if is_thinlto else None,
+        additional_flags=additional_flags,
+        delete_flags=delete_flags,
+        cmd_override=cmd_override)
+    module_specs.append(ModuleSpec(tuple(exec_cmd), extra_options, module_path))
+
+  return module_specs
+
+
+def _has_thinlto_index(module_paths: Iterable[str]) -> bool:
+  return tf.io.gfile.exists(next(iter(module_paths)) + '.thinlto.bc')
+
+
+def _has_cmd(module_paths: Iterable[str]) -> bool:
+  return tf.io.gfile.exists(next(iter(module_paths)) + '.cmd')
+
+
+def _load_module_paths(data_path) -> List[str]:
+  module_paths_path = os.path.join(data_path, 'module_paths')
+  with open(module_paths_path, 'r', encoding='utf-8') as f:
+    ret = [os.path.join(data_path, name.rstrip('\n')) for name in f]
+    if len(ret) == 0:
+      logging.error('%s is empty.', module_paths_path)
+      raise ValueError
+    return ret
+
+
+def _load_metadata(metadata_path: str) -> Dict[any, any]:
+  try:
+    with open(metadata_path, 'r', encoding='utf-8') as f:
+      return json.load(f)
+  except FileNotFoundError:
+    logging.info('%s couldn\'t be found.', metadata_path)
+    return {}
+
+
+def _load_and_parse_command(cmd_file: Optional[str],
+                            ir_file: str,
+                            thinlto_file: Optional[str] = None,
+                            additional_flags: Tuple[str, ...] = (),
+                            delete_flags: Tuple[str, ...] = (),
+                            cmd_override: Tuple[str, ...] = None) -> List[str]:
+  """Loads and cleans up base command line.
+
+  Remove certain unnecessary flags, and add the .bc file to compile and, if
+  given, the thinlto index.
+
+  Args:
+    cmd_file: Path to a .cmd file (from corpus).
+    ir_file: The path to the ir file to compile.
+    thinlto_file: The path to the thinlto index, or None.
+    additional_flags: Tuple of flags to add.
+    delete_flags: Tuple of flags to remove.
+
+  Returns:
+    The argument list to pass to the compiler process.
+  """
+  if cmd_override is not None:
+    option_iterator = iter(cmd_override)
+  elif cmd_file is not None:
+    with open(cmd_file, encoding='utf-8') as f:
+      option_iterator = iter(f.read().split('\0'))
+  else:
+    logging.error('.cmd file not available and no command override specified.')
+    raise ValueError
+
+  cmdline = []
+  option = next(option_iterator, None)
+  while option:
+    if any(option.startswith(flag) for flag in delete_flags):
+      if '=' not in option:
+        next(option_iterator, None)
+    else:
+      cmdline.append(option)
+    option = next(option_iterator, None)
+
+  cmdline.extend(['-x', 'ir', ir_file])
+
+  if thinlto_file:
+    cmdline.append('-fthinlto-index=' + thinlto_file)
+    cmdline += ['-mllvm', '-thinlto-assume-merged']
+
+  cmdline.extend(additional_flags)
+
+  if cmd_file is not None and cmd_override is None:
+    # Ensure that -cc1 is always present
+    if cmdline[0] != '-cc1':
+      cmdline = ['-cc1'] + cmdline
+
+  return cmdline

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ModuleSpec definition and utility command line parsing functions."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ModuleSpec:
+  """Dataclass describing an input module and its compilation command options.
+  """
+  exec_cmd: Tuple[str, ...]
+  extra_opts: dict[str, Tuple[str, ...]]
+  name: str

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -1,0 +1,269 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ModuleSpec dataclass and its utility functions."""
+# pylint: disable=protected-access
+
+import tensorflow as tf
+import json
+import os
+
+from compiler_opt.rl import corpus
+
+
+class CommandParsingTest(tf.test.TestCase):
+
+  def test_thinlto_file(self):
+    data = ['-cc1', '-foo', '-bar=baz']
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(argfile.full_path, 'my_file.bc'),
+        ['-cc1', '-foo', '-bar=baz', '-x', 'ir', 'my_file.bc'])
+    self.assertEqual(
+        corpus._load_and_parse_command(argfile.full_path, 'my_file.bc',
+                                       'the_index.bc'),
+        [
+            '-cc1', '-foo', '-bar=baz', '-x', 'ir', 'my_file.bc',
+            '-fthinlto-index=the_index.bc', '-mllvm', '-thinlto-assume-merged'
+        ])
+
+  def test_deletion(self):
+    delete_compilation_flags = ('-split-dwarf-file', '-split-dwarf-output',
+                                '-fthinlto-index', '-fprofile-sample-use',
+                                '-fprofile-remapping-file')
+    data = [
+        '-cc1', '-fthinlto-index=bad', '-split-dwarf-file', '/tmp/foo.dwo',
+        '-split-dwarf-output', 'somepath/some.dwo'
+    ]
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            argfile.full_path, 'hi.bc', delete_flags=delete_compilation_flags),
+        ['-cc1', '-x', 'ir', 'hi.bc'])
+
+  def test_addition(self):
+    additional_flags = ('-fix-all-bugs',)
+    data = ['-cc1']
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            argfile.full_path, 'hi.bc', additional_flags=additional_flags),
+        ['-cc1', '-x', 'ir', 'hi.bc', '-fix-all-bugs'])
+
+  def test_override(self):
+    cmd_override = ('-fix-all-bugs',)
+    data = ['-cc1', '-fthinlto-index=bad']
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            argfile.full_path,
+            'hi.bc',
+            cmd_override=cmd_override,
+            additional_flags=('-add-bugs',),
+            delete_flags=('-fthinlto-index',)),
+        ['-fix-all-bugs', '-x', 'ir', 'hi.bc', '-add-bugs'])
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            None, 'hi.bc', cmd_override=cmd_override),
+        ['-fix-all-bugs', '-x', 'ir', 'hi.bc'])
+
+  def test_cmd_not_provided(self):
+    self.assertRaises(
+        ValueError,
+        corpus._load_and_parse_command,
+        None,
+        'hi.bc',
+        cmd_override=None,
+        additional_flags=('-add-bugs',),
+        delete_flags=('-fthinlto-index',))
+
+  def test_modification(self):
+    delete_compilation_flags = ('-split-dwarf-file', '-split-dwarf-output',
+                                '-fthinlto-index', '-fprofile-sample-use',
+                                '-fprofile-remapping-file')
+    additional_flags = ('-fix-all-bugs',)
+    data = [
+        '-cc1', '-fthinlto-index=bad', '-split-dwarf-file', '/tmp/foo.dwo',
+        '-split-dwarf-output', 'somepath/some.dwo'
+    ]
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            argfile.full_path,
+            'hi.bc',
+            delete_flags=delete_compilation_flags,
+            additional_flags=additional_flags),
+        ['-cc1', '-x', 'ir', 'hi.bc', '-fix-all-bugs'])
+
+  def test_add_cc1(self):
+    data = ['-fix-all-bugs', '-xyz']
+    argfile = self.create_tempfile(content='\0'.join(data))
+    self.assertEqual(
+        corpus._load_and_parse_command(argfile.full_path, 'hi.bc'),
+        ['-cc1', '-fix-all-bugs', '-xyz', '-x', 'ir', 'hi.bc'])
+
+
+class LoadMetadataTest(tf.test.TestCase):
+
+  def test_exists(self):
+    data = {'abc': 123}
+    metadata_file = self.create_tempfile(content=json.dumps(data))
+    read_data = corpus._load_metadata(metadata_file.full_path)
+    self.assertEqual(data, read_data)
+
+  def test_not_exists(self):
+    read_data = corpus._load_metadata('this#file$cant:possibly^exist')
+    self.assertEqual({}, read_data)
+
+
+class LoadModulePathsTest(tf.test.TestCase):
+
+  def test_exists(self):
+    data = ['1', '2', '3']
+    tempdir = self.create_tempdir()
+    tempdir.create_file(file_path='module_paths', content='\n'.join(data))
+    read_data = corpus._load_module_paths(tempdir.full_path)
+    self.assertEqual([os.path.join(tempdir.full_path, p) for p in data],
+                     read_data)
+
+  def test_empty(self):
+    tempdir = self.create_tempdir()
+    tempdir.create_file(file_path='module_paths')
+    self.assertRaises(ValueError, corpus._load_module_paths, tempdir.full_path)
+
+  def test_not_exists_file(self):
+    tempdir = self.create_tempdir()
+    self.assertRaises(FileNotFoundError, corpus._load_module_paths,
+                      tempdir.full_path)
+
+  def test_not_exists_dir(self):
+    self.assertRaises(FileNotFoundError, corpus._load_module_paths,
+                      '/this#path$cant:possibly^exist')
+
+
+class HasCmdTest(tf.test.TestCase):
+
+  def test_exists(self):
+    tempdir = self.create_tempdir()
+    tempdir.create_file(file_path='a.cmd')
+    self.assertTrue(corpus._has_cmd(iter([tempdir.full_path + '/a'])))
+
+  def test_not_exists(self):
+    self.assertFalse(corpus._has_cmd(iter(['this#file$cant:possibly^exist'])))
+
+
+class HasThinLTOIndexTest(tf.test.TestCase):
+
+  def test_exists(self):
+    tempdir = self.create_tempdir()
+    tempdir.create_file(file_path='a.thinlto.bc')
+    self.assertTrue(corpus._has_thinlto_index(iter([tempdir.full_path + '/a'])))
+
+  def test_not_exists(self):
+    self.assertFalse(
+        corpus._has_thinlto_index(iter(['this#file$cant:possibly^exist'])))
+
+
+class ModuleSpecTest(tf.test.TestCase):
+
+  def test_cmd(self):
+    ms = corpus.ModuleSpec(
+        exec_cmd=('-cc1', '-fix-all-bugs'),
+        extra_opts={
+            'mllvm': ('-mllvm', '{opt:s}'),
+            'std': ('{opt:s}',)
+        },
+        name='dummy')
+    self.assertEqual(ms.name, 'dummy')
+    self.assertEqual(ms.cmd(), ['-cc1', '-fix-all-bugs'])
+    self.assertEqual(ms.cmd([]), ['-cc1', '-fix-all-bugs'])
+    self.assertEqual(
+        ms.cmd([('-policy=path',)]), ['-cc1', '-fix-all-bugs', '-policy=path'])
+    self.assertEqual(
+        ms.cmd([('-mllvm', '-policy=path')]),
+        ['-cc1', '-fix-all-bugs', '-mllvm', '-policy=path'])
+    self.assertEqual(
+        ms.cmd([('-mllvm', '-policy=path'), ('-nomllvm',)]),
+        ['-cc1', '-fix-all-bugs', '-mllvm', '-policy=path', '-nomllvm'])
+    self.assertRaises(ValueError, ms.cmd, [('-miivm', '-policy=path')])
+    self.assertRaises(ValueError, ms.cmd,
+                      [('-miivm', '-policy=path', '-extra-opt')])
+
+  def test_get(self):
+    data = ['1', '2']
+    tempdir = self.create_tempdir()
+    tempdir.create_file('module_paths', content='\n'.join(data))
+    tempdir.create_file('1.bc')
+    tempdir.create_file('1.thinlto.bc')
+    tempdir.create_file(
+        '1.cmd', content='\0'.join(['-cc1', '-fthinlto-index=xyz']))
+    tempdir.create_file('2.bc')
+    tempdir.create_file('2.thinlto.bc')
+    tempdir.create_file('2.cmd', content='\0'.join(['-fthinlto-index=abc']))
+
+    ms_list = corpus.read(
+        tempdir.full_path,
+        additional_flags=('-add',),
+        delete_flags=('-fthinlto-index',))
+    self.assertEqual(len(ms_list), 2)
+    ms1 = ms_list[0]
+    ms2 = ms_list[1]
+    self.assertEqual(ms1.name, tempdir.full_path + '/1')
+    self.assertEqual(ms1.exec_cmd,
+                     ('-cc1', '-x', 'ir', tempdir.full_path + '/1.bc',
+                      '-fthinlto-index=' + tempdir.full_path + '/1.thinlto.bc',
+                      '-mllvm', '-thinlto-assume-merged', '-add'))
+
+    self.assertEqual(ms2.name, tempdir.full_path + '/2')
+    self.assertEqual(ms2.exec_cmd,
+                     ('-cc1', '-x', 'ir', tempdir.full_path + '/2.bc',
+                      '-fthinlto-index=' + tempdir.full_path + '/2.thinlto.bc',
+                      '-mllvm', '-thinlto-assume-merged', '-add'))
+
+  def test_get_with_metadata(self):
+    data = ['1', '2']
+    metadata = {'global_command_override': ['-O3', '-qrs']}
+    tempdir = self.create_tempdir()
+    tempdir.create_file('module_paths', content='\n'.join(data))
+    tempdir.create_file('metadata.json', content=json.dumps(metadata))
+    tempdir.create_file('1.bc')
+    tempdir.create_file('1.thinlto.bc')
+    tempdir.create_file(
+        '1.cmd', content='\0'.join(['-cc1', '-fthinlto-index=xyz']))
+    tempdir.create_file('2.bc')
+    tempdir.create_file('2.thinlto.bc')
+    tempdir.create_file('2.cmd', content='\0'.join(['-fthinlto-index=abc']))
+
+    ms_list = corpus.read(
+        tempdir.full_path,
+        additional_flags=('-add',),
+        delete_flags=('-fthinlto-index',))
+    self.assertEqual(len(ms_list), 2)
+    ms1 = ms_list[0]
+    ms2 = ms_list[1]
+    self.assertEqual(ms1.name, tempdir.full_path + '/1')
+    self.assertEqual(ms1.exec_cmd,
+                     ('-O3', '-qrs', '-x', 'ir', tempdir.full_path + '/1.bc',
+                      '-fthinlto-index=' + tempdir.full_path + '/1.thinlto.bc',
+                      '-mllvm', '-thinlto-assume-merged', '-add'))
+
+    self.assertEqual(ms2.name, tempdir.full_path + '/2')
+    self.assertEqual(ms2.exec_cmd,
+                     ('-O3', '-qrs', '-x', 'ir', tempdir.full_path + '/2.bc',
+                      '-fthinlto-index=' + tempdir.full_path + '/2.thinlto.bc',
+                      '-mllvm', '-thinlto-assume-merged', '-add'))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -82,19 +82,14 @@ class InliningRunner(compilation_runner.CompilationRunner):
       command_line = []
       if self._launcher_path:
         command_line.append(self._launcher_path)
-      command_line.extend([self._clang_path] +
-                          compilation_runner.get_command_line_for_bundle(
-                              module_spec.name + '.cmd',
-                              module_spec.name + '.bc',
-                              additional_flags=self._additional_flags,
-                              delete_flags=self._delete_flags) + [
-                                  '-mllvm', '-enable-ml-inliner=development',
-                                  '-mllvm', '-training-log=' +
-                                  log_path, '-o', output_native_path
-                              ])
+      command_line.append(self._clang_path)
+      additional_flags = [('-mllvm', '-enable-ml-inliner=development'),
+                          ('-mllvm', f'-training-log={output_native_path}')]
       if tf_policy_path:
-        command_line.extend(
-            ['-mllvm', '-ml-inliner-model-under-training=' + tf_policy_path])
+        additional_flags.append(
+            ('-mllvm', f'-ml-inliner-model-under-training={tf_policy_path}'))
+      command_line.extend(module_spec.cmd(additional_flags))
+
       compilation_runner.start_cancellable_process(command_line,
                                                    self._compilation_timeout,
                                                    cancellation_manager)

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -23,6 +23,7 @@ import gin
 import tensorflow as tf
 
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 
 _DEFAULT_IDENTIFIER = 'default'
 
@@ -45,14 +46,14 @@ class InliningRunner(compilation_runner.CompilationRunner):
     self._llvm_size_path = llvm_size_path
 
   def _compile_fn(
-      self, file_paths: Tuple[str, str], tf_policy_path: str, reward_only: bool,
-      cancellation_manager: Optional[
+      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      reward_only: bool, cancellation_manager: Optional[
           compilation_runner.WorkerCancellationManager]
   ) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Run inlining for the given IR file under the given policy.
 
     Args:
-      file_paths: path to files needed for inlining, Tuple of (.bc, .cmd).
+      module_spec: a ModuleSpec.
       tf_policy_path: path to TF policy direcoty on local disk.
       reward_only: whether only return native size.
       cancellation_manager: handler for early termination by killing any running
@@ -75,8 +76,6 @@ class InliningRunner(compilation_runner.CompilationRunner):
     log_path = os.path.join(working_dir, 'log')
     output_native_path = os.path.join(working_dir, 'native')
 
-    input_ir_path, cmd_path = file_paths
-
     sequence_example = tf.train.SequenceExample()
     native_size = 0
     try:
@@ -85,8 +84,8 @@ class InliningRunner(compilation_runner.CompilationRunner):
         command_line.append(self._launcher_path)
       command_line.extend([self._clang_path] +
                           compilation_runner.get_command_line_for_bundle(
-                              cmd_path,
-                              input_ir_path,
+                              module_spec.name + '.cmd',
+                              module_spec.name + '.bc',
                               additional_flags=self._additional_flags,
                               delete_flags=self._delete_flags) + [
                                   '-mllvm', '-enable-ml-inliner=development',

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -26,6 +26,7 @@ import tensorflow as tf
 from tf_agents.system import system_multiprocessing as multiprocessing
 
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 from compiler_opt.rl import data_collector
 from compiler_opt.rl import local_data_collector
 
@@ -47,8 +48,8 @@ def _get_sequence_example(feature_value):
   return text_format.Parse(sequence_example_text, tf.train.SequenceExample())
 
 
-def mock_collect_data(file_paths, tf_policy_dir, reward_stat, _):
-  assert file_paths == ('a', 'b')
+def mock_collect_data(module_spec, tf_policy_dir, reward_stat, _):
+  assert module_spec.name == 'dummy'
   assert tf_policy_dir == 'policy'
   assert reward_stat is None or reward_stat == {
       'default':
@@ -87,7 +88,7 @@ class Sleeper(compilation_runner.CompilationRunner):
     self._living = living
     self._lock = mp.Manager().Lock()
 
-  def collect_data(self, file_paths, tf_policy_path, reward_stat,
+  def collect_data(self, module_spec, tf_policy_path, reward_stat,
                    cancellation_token):
     _ = reward_stat
     cancellation_manager = self._get_cancellation_manager(cancellation_token)
@@ -132,7 +133,9 @@ class LocalDataCollectorTest(tf.test.TestCase):
       return _test_iterator_fn
 
     collector = local_data_collector.LocalDataCollector(
-        file_paths=tuple([('a', 'b')] * 100),
+        module_specs=[
+            corpus.ModuleSpec(exec_cmd=('-O2',), extra_opts={}, name='dummy')
+        ] * 100,
         num_workers=4,
         num_modules=9,
         runner=mock_compilation_runner,
@@ -198,7 +201,9 @@ class LocalDataCollectorTest(tf.test.TestCase):
         return False
 
     collector = local_data_collector.LocalDataCollector(
-        file_paths=tuple([('a', 'b')] * 200),
+        module_specs=[
+            corpus.ModuleSpec(exec_cmd=('-O2',), extra_opts={}, name='dummy')
+        ] * 200,
         num_workers=4,
         num_modules=4,
         runner=mock_compilation_runner,

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -99,7 +99,3 @@ class ProblemConfiguration(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def get_runner_type(self) -> 'type[compilation_runner.CompilationRunner]':
     raise NotImplementedError
-
-
-def is_thinlto(module_paths: Iterable[str]) -> bool:
-  return tf.io.gfile.exists(next(iter(module_paths)) + '.thinlto.bc')

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -19,7 +19,6 @@ import io
 import os
 import tempfile
 from typing import Dict, Optional, Tuple
-from absl import logging
 
 import gin
 import tensorflow as tf
@@ -27,6 +26,7 @@ import tensorflow as tf
 # This is https://github.com/google/pytype/issues/764
 from google.protobuf import struct_pb2  # pytype: disable=pyi-error
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 
 
 @gin.configurable(module='runners')
@@ -44,19 +44,18 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
   # TODO: refactor file_paths parameter to ensure correctness during
   # construction
   def _compile_fn(
-      self, file_paths: Tuple[str, ...], tf_policy_path: str, reward_only: bool,
-      cancellation_manager: Optional[
+      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      reward_only: bool, cancellation_manager: Optional[
           compilation_runner.WorkerCancellationManager]
   ) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Run inlining for the given IR file under the given policy.
 
     Args:
-      file_paths: path to files needed for inlining, Tuple of (.bc, .cmd,
-        .thinlto.bc).
+      module_spec: a ModuleSpec.
       tf_policy_path: path to TF policy direcoty on local disk.
       reward_only: whether only return reward.
       cancellation_manager: handler for early termination by killing any running
-      processes
+        processes
 
     Returns:
       A dict mapping from example identifier to tuple containing:
@@ -75,28 +74,20 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
     log_path = os.path.join(working_dir, 'log')
     output_native_path = os.path.join(working_dir, 'native')
 
-    input_ir_path = cmd_path = thinlto_index_path = None
-    if len(file_paths) == 3:
-      input_ir_path, cmd_path, thinlto_index_path = file_paths
-    elif len(file_paths) == 2:
-      input_ir_path, cmd_path = file_paths
-    else:
-      logging.fatal('Expected 2 or 3 file paths')
-
     result = {}
     try:
       command_line = []
       if self._launcher_path:
         command_line.append(self._launcher_path)
-      command_line.extend([self._clang_path] +
-                          compilation_runner.get_command_line_for_bundle(
-                              cmd_path, input_ir_path, thinlto_index_path,
-                              self._additional_flags, self._delete_flags) + [
-                                  '-mllvm', '-thinlto-assume-merged', '-mllvm',
-                                  '-regalloc-enable-advisor=development',
-                                  '-mllvm', '-regalloc-training-log=' +
-                                  log_path, '-o', output_native_path
-                              ])
+      command_line.extend(
+          [self._clang_path] + compilation_runner.get_command_line_for_bundle(
+              module_spec.name + '.cmd', module_spec.name +
+              '.bc', module_spec.name +
+              '.thinlto.bc', self._additional_flags, self._delete_flags) + [
+                  '-mllvm', '-thinlto-assume-merged', '-mllvm',
+                  '-regalloc-enable-advisor=development', '-mllvm',
+                  '-regalloc-training-log=' + log_path, '-o', output_native_path
+              ])
 
       if tf_policy_path:
         command_line.extend(['-mllvm', '-regalloc-model=' + tf_policy_path])

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -100,20 +100,13 @@ def train_eval(agent_name=constant.AgentName.PPO,
   }
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 
-  with open(
-      os.path.join(FLAGS.data_path, 'module_paths'), 'r',
-      encoding='utf-8') as f:
-    module_specs = [
-        corpus.ModuleSpec(
-            name=os.path.join(FLAGS.data_path, name.rstrip('\n')),
-            exec_cmd=(),
-            extra_opts={}) for name in f
-    ]
+  logging.info('Loading module specs from corpus')
+  module_specs = corpus.read(FLAGS.data_path, additional_compilation_flags,
+                             delete_compilation_flags)
+  logging.info('Done loading module specs from corpus')
 
   runner = problem_config.get_runner_type()(
-      moving_average_decay_rate=moving_average_decay_rate,
-      additional_flags=additional_compilation_flags,
-      delete_flags=delete_compilation_flags)
+      moving_average_decay_rate=moving_average_decay_rate)
 
   dataset_fn = data_reader.create_sequence_example_dataset_fn(
       agent_name=agent_name,

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -127,16 +127,11 @@ def main(_):
   runner = problem_config.get_runner_type()(moving_average_decay_rate=0)
   assert runner
 
-  with open(
-      os.path.join(_DATA_PATH.value, 'module_paths'), 'r',
-      encoding='utf-8') as f:
-    module_specs = [
-        corpus.ModuleSpec(
-            name=os.path.join(_DATA_PATH.value, name.rstrip('\n')),
-            exec_cmd=(),
-            extra_opts={}) for name in f
-    ]
-
+  module_specs = corpus.read(
+      _DATA_PATH.value,
+      delete_flags=('-split-dwarf-file', '-split-dwarf-output',
+                    '-fthinlto-index', '-fprofile-sample-use',
+                    '-fprofile-remapping-file'))
   if _MODULE_FILTER.value:
     m = re.compile(_MODULE_FILTER.value)
     module_specs = [ms for ms in module_specs if m.match(ms.name)]


### PR DESCRIPTION
Rewrote the commit history of #45 and didn't want to wipe that PR's comments out, so making a new PR instead.

First commit crudely switches from file_paths to ModuleSpec (and has regressions), second commit completes the switch with new functions/flow.

- The file_paths tuple is replaced with a ModuleSpec dataclass.
This has the benefit of not recomputing the entire command line options on each compilation, and also simplifies/unifies runners' inputs.

- Adds ThinLTO support for the inlining runner.

- Corpus-specific command options overrides can now be specified via metadata.json. (for linker invoked ThinLTO corpus training)

- Extension to support corpus-specific command option additions should also be (trivially) implementable in the future. (b/233935329)

- Fix generate_default_trace regression from https://github.com/google/ml-compiler-opt/commit/09b41a8bda02ebfe47c5e9bc8149dbf9537b9fe4 (missing delete_flags)