### PR TITLE
Refactor file_paths tuple into ModuleSpec (preliminary)

### DIFF
--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -28,6 +28,7 @@ from google.protobuf import text_format  # pytype: disable=pyi-error
 
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import constant
+from compiler_opt.rl import corpus
 
 _DEFAULT_FEATURE_VALUE = 12
 _POLICY_FEATURE_VALUE = 34
@@ -107,7 +108,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'),
+        module_spec=corpus.ModuleSpec(name='dummy'),
         tf_policy_path='policy_path',
         reward_stat=None)
     self.assertEqual(2, mock_compile_fn.call_count)
@@ -138,7 +139,9 @@ class CompilationRunnerTest(tf.test.TestCase):
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'), tf_policy_path='', reward_stat=None)
+        module_spec=corpus.ModuleSpec(name='dummy'),
+        tf_policy_path='',
+        reward_stat=None)
     # One call when we ask for the default policy, because it can provide both
     # trace and default size.
     self.assertEqual(1, mock_compile_fn.call_count)
@@ -167,7 +170,7 @@ class CompilationRunnerTest(tf.test.TestCase):
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
     data = runner.collect_data(
-        file_paths=('bc', 'cmd'),
+        module_spec=corpus.ModuleSpec(name='dummy'),
         tf_policy_path='policy_path',
         reward_stat={
             'default':
@@ -204,7 +207,7 @@ class CompilationRunnerTest(tf.test.TestCase):
 
     with self.assertRaisesRegex(subprocess.CalledProcessError, 'error'):
       _ = runner.collect_data(
-          file_paths=('bc', 'cmd'),
+          module_spec=corpus.ModuleSpec(name='dummy'),
           tf_policy_path='policy_path',
           reward_stat=None)
     self.assertEqual(1, mock_compile_fn.call_count)

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ModuleSpec definition and utility command line parsing functions."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ModuleSpec:
+  """Dataclass describing an input module and its compilation command options.
+  """
+  name: str
+  has_thinlto: bool = False

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -23,6 +23,7 @@ import gin
 import tensorflow as tf
 
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 
 _DEFAULT_IDENTIFIER = 'default'
 
@@ -45,14 +46,14 @@ class InliningRunner(compilation_runner.CompilationRunner):
     self._llvm_size_path = llvm_size_path
 
   def _compile_fn(
-      self, file_paths: Tuple[str, str], tf_policy_path: str, reward_only: bool,
-      cancellation_manager: Optional[
+      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      reward_only: bool, cancellation_manager: Optional[
           compilation_runner.WorkerCancellationManager]
   ) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Run inlining for the given IR file under the given policy.
 
     Args:
-      file_paths: path to files needed for inlining, Tuple of (.bc, .cmd).
+      module_spec: a ModuleSpec.
       tf_policy_path: path to TF policy direcoty on local disk.
       reward_only: whether only return native size.
       cancellation_manager: handler for early termination by killing any running
@@ -75,24 +76,22 @@ class InliningRunner(compilation_runner.CompilationRunner):
     log_path = os.path.join(working_dir, 'log')
     output_native_path = os.path.join(working_dir, 'native')
 
-    input_ir_path, cmd_path = file_paths
-
     sequence_example = tf.train.SequenceExample()
     native_size = 0
     try:
       command_line = []
       if self._launcher_path:
         command_line.append(self._launcher_path)
-      command_line.extend([self._clang_path] +
-                          compilation_runner.get_command_line_for_bundle(
-                              cmd_path,
-                              input_ir_path,
-                              additional_flags=self._additional_flags,
-                              delete_flags=self._delete_flags) + [
-                                  '-mllvm', '-enable-ml-inliner=development',
-                                  '-mllvm', '-training-log=' +
-                                  log_path, '-o', output_native_path
-                              ])
+      command_line.extend(
+          [self._clang_path] + compilation_runner.get_command_line_for_bundle(
+              module_spec.name + '.cmd',
+              module_spec.name + '.bc', (module_spec.name + '.thinlto.bc'
+                                        ) if module_spec.has_thinlto else None,
+              additional_flags=self._additional_flags,
+              delete_flags=self._delete_flags) + [
+                  '-mllvm', '-enable-ml-inliner=development', '-mllvm',
+                  '-training-log=' + log_path, '-o', output_native_path
+              ])
       if tf_policy_path:
         command_line.extend(
             ['-mllvm', '-ml-inliner-model-under-training=' + tf_policy_path])

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -25,6 +25,7 @@ from tf_agents.system import system_multiprocessing as multiprocessing
 
 from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPool
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 from compiler_opt.rl import data_collector
 from compiler_opt.rl import local_data_collector
 
@@ -46,8 +47,8 @@ def _get_sequence_example(feature_value):
   return text_format.Parse(sequence_example_text, tf.train.SequenceExample())
 
 
-def mock_collect_data(file_paths, tf_policy_dir, reward_stat):
-  assert file_paths == ('a', 'b')
+def mock_collect_data(module_spec, tf_policy_dir, reward_stat):
+  assert module_spec.name == 'dummy'
   assert tf_policy_dir == 'policy'
   assert reward_stat is None or reward_stat == {
       'default':
@@ -114,7 +115,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          file_paths=tuple([('a', 'b')] * 100),
+          module_specs=[corpus.ModuleSpec(name='dummy')] * 100,
           num_modules=9,
           worker_pool=lwp,
           parser=create_test_iterator_fn(),
@@ -175,7 +176,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          file_paths=tuple([('a', 'b')] * 200),
+          module_specs=[corpus.ModuleSpec(name='dummy')] * 200,
           num_modules=4,
           worker_pool=lwp,
           parser=parser,

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -19,7 +19,6 @@ import io
 import os
 import tempfile
 from typing import Dict, Optional, Tuple
-from absl import logging
 
 import gin
 import tensorflow as tf
@@ -27,6 +26,7 @@ import tensorflow as tf
 # This is https://github.com/google/pytype/issues/764
 from google.protobuf import struct_pb2  # pytype: disable=pyi-error
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 
 
 @gin.configurable(module='runners')
@@ -44,19 +44,18 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
   # TODO: refactor file_paths parameter to ensure correctness during
   # construction
   def _compile_fn(
-      self, file_paths: Tuple[str, ...], tf_policy_path: str, reward_only: bool,
-      cancellation_manager: Optional[
+      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      reward_only: bool, cancellation_manager: Optional[
           compilation_runner.WorkerCancellationManager]
   ) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Run inlining for the given IR file under the given policy.
 
     Args:
-      file_paths: path to files needed for inlining, Tuple of (.bc, .cmd,
-        .thinlto.bc).
+      module_spec: a ModuleSpec.
       tf_policy_path: path to TF policy direcoty on local disk.
       reward_only: whether only return reward.
       cancellation_manager: handler for early termination by killing any running
-      processes
+        processes
 
     Returns:
       A dict mapping from example identifier to tuple containing:
@@ -75,28 +74,20 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
     log_path = os.path.join(working_dir, 'log')
     output_native_path = os.path.join(working_dir, 'native')
 
-    input_ir_path = cmd_path = thinlto_index_path = None
-    if len(file_paths) == 3:
-      input_ir_path, cmd_path, thinlto_index_path = file_paths
-    elif len(file_paths) == 2:
-      input_ir_path, cmd_path = file_paths
-    else:
-      logging.fatal('Expected 2 or 3 file paths')
-
     result = {}
     try:
       command_line = []
       if self._launcher_path:
         command_line.append(self._launcher_path)
-      command_line.extend([self._clang_path] +
-                          compilation_runner.get_command_line_for_bundle(
-                              cmd_path, input_ir_path, thinlto_index_path,
-                              self._additional_flags, self._delete_flags) + [
-                                  '-mllvm', '-thinlto-assume-merged', '-mllvm',
-                                  '-regalloc-enable-advisor=development',
-                                  '-mllvm', '-regalloc-training-log=' +
-                                  log_path, '-o', output_native_path
-                              ])
+      command_line.extend(
+          [self._clang_path] + compilation_runner.get_command_line_for_bundle(
+              module_spec.name + '.cmd', module_spec.name + '.bc',
+              (module_spec.name + '.thinlto.bc') if module_spec.has_thinlto else
+              None, self._additional_flags, self._delete_flags) + [
+                  '-mllvm', '-thinlto-assume-merged', '-mllvm',
+                  '-regalloc-enable-advisor=development', '-mllvm',
+                  '-regalloc-training-log=' + log_path, '-o', output_native_path
+              ])
 
       if tf_policy_path:
         command_line.extend(['-mllvm', '-regalloc-model=' + tf_policy_path])

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -31,6 +31,7 @@ import multiprocessing
 import tensorflow as tf
 
 from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import corpus
 from compiler_opt.rl import problem_configuration
 from compiler_opt.rl import registry
 
@@ -79,7 +80,7 @@ def get_runner() -> compilation_runner.CompilationRunner:
                     '-fprofile-remapping-file'))
 
 
-def worker(policy_path: str, work_queue: 'queue.Queue[Tuple[str, ...]]',
+def worker(policy_path: str, work_queue: 'queue.Queue[corpus.ModuleSpec]',
            results_queue: 'queue.Queue[Optional[List[str]]]',
            key_filter: Optional[str]):
   """Describes the job each paralleled worker process does.
@@ -101,16 +102,14 @@ def worker(policy_path: str, work_queue: 'queue.Queue[Tuple[str, ...]]',
 
   while True:
     try:
-      module_triple = work_queue.get_nowait()
+      module_spec = work_queue.get_nowait()
     except queue.Empty:
       return
     try:
       data = runner.collect_data(
-          file_paths=module_triple,
-          tf_policy_path=policy_path,
-          reward_stat=None)
+          module_spec=module_spec, tf_policy_path=policy_path, reward_stat=None)
       if not m:
-        results_queue.put((module_triple[0], data.serialized_sequence_examples,
+        results_queue.put((module_spec.name, data.serialized_sequence_examples,
                            data.reward_stats))
         continue
       new_reward_stats = {}
@@ -122,10 +121,10 @@ def worker(policy_path: str, work_queue: 'queue.Queue[Tuple[str, ...]]',
         new_reward_stats[k] = data.reward_stats[k]
         new_sequence_examples.append(sequence_example)
       results_queue.put(
-          (module_triple[0], new_sequence_examples, new_reward_stats))
+          (module_spec.name, new_sequence_examples, new_reward_stats))
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
             RuntimeError):
-      logging.error('Failed to compile %s.', module_triple)
+      logging.error('Failed to compile %s.', module_spec.name)
       results_queue.put(None)
 
 
@@ -138,29 +137,31 @@ def main(_):
   with open(
       os.path.join(_DATA_PATH.value, 'module_paths'), 'r',
       encoding='utf-8') as f:
-    module_paths = [
-        os.path.join(_DATA_PATH.value, name.rstrip('\n')) for name in f
+    lines = f.readlines()
+    has_thinlto = problem_configuration.is_thinlto(
+        [os.path.join(_DATA_PATH.value, lines[0].rstrip('\n'))])
+    module_specs = [
+        corpus.ModuleSpec(
+            name=os.path.join(_DATA_PATH.value, name.rstrip('\n')),
+            has_thinlto=has_thinlto) for name in lines
     ]
-  is_thinlto = problem_configuration.is_thinlto(module_paths)
-  file_suffix = ('.bc', '.cmd', '.thinlto.bc') if is_thinlto else ('.bc',
-                                                                   '.cmd')
+
   if _MODULE_FILTER.value:
     m = re.compile(_MODULE_FILTER.value)
-    module_paths = [mp for mp in module_paths if m.match(mp)]
+    module_specs = [ms for ms in module_specs if m.match(ms.name)]
 
   # Sampling if needed.
   if _SAMPLING_RATE.value < 1:
-    sampled_modules = int(len(module_paths) * _SAMPLING_RATE.value)
-    module_paths = random.sample(module_paths, k=sampled_modules)
+    sampled_modules = int(len(module_specs) * _SAMPLING_RATE.value)
+    module_specs = random.sample(module_specs, k=sampled_modules)
 
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel
-  sizes_and_paths = [(os.path.getsize(p + '.bc'), p) for p in module_paths]
-  sizes_and_paths.sort(reverse=True)
-  sorted_module_paths = [p for _, p in sizes_and_paths]
-  module_specs = [
-      tuple(p + suffix for suffix in file_suffix) for p in sorted_module_paths
+  sizes_and_specs = [
+      (os.path.getsize(m.name + '.bc'), i) for i, m in enumerate(module_specs)
   ]
+  sizes_and_specs.sort(reverse=True)
+  module_specs = [module_specs[i] for _, i in sizes_and_specs]
 
   worker_count = (
       min(os.cpu_count(), _NUM_WORKERS.value)
@@ -177,8 +178,8 @@ def main(_):
     with performance_context as performance_writer:
       ctx = multiprocessing.get_context()
       m = ctx.Manager()
-      results_queue: ('queue.Queue[ResultsQueueEntry]') = m.Queue()
-      work_queue: 'queue.Queue[Tuple[str, ...]]' = m.Queue()
+      results_queue: 'queue.Queue[ResultsQueueEntry]' = m.Queue()
+      work_queue: 'queue.Queue[corpus.ModuleSpec]' = m.Queue()
       for module_spec in module_specs:
         work_queue.put(module_spec)
 


### PR DESCRIPTION
Preliminary patch to refactoring file_paths tuple usage completely.

Allows distributed thinlto corpora to be optionally trained on independent of runner type

Prereq: #55 #56 