### PR TITLE
Add support for extracting lld-thinlto corpora

### DIFF
--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -30,6 +30,7 @@ In a ThinLTO case, the compilation is assumed to have been performed specifying
 import json
 import multiprocessing
 import os
+import pathlib
 import re
 import shutil
 import subprocess
@@ -59,11 +60,15 @@ flags.DEFINE_string(
     'Include only those modules with a command line matching this regexp. '
     'Setting it to None for not filtering. Note that the regexp is applied '
     'independently for each separate command line option. For example, ^-Oz$ '
-    'will match Oz - built binaries.')
-flags.DEFINE_bool(
-    'thinlto_build', False, 'Set if the build was ThinLTO, to '
-    'ensure index files are also copied. The build is assumed to have had'
-    '-mllvm -lto-embed-bitcode=post-merge-pre-opt passed to clang.')
+    'will match Oz - built binaries. Does not work with thinlto_build=lld.')
+flags.DEFINE_enum(
+    'thinlto_build', None, ['clang', 'lld'],
+    'Set to \'clang\', or \'lld\' if the build was ThinLTO-ed by clang or lld '
+    'respectively. This ensures the thinlto.bc files are also copied. '
+    'The build is assumed to have had '
+    '-mllvm -lto-embed-bitcode=post-merge-pre-opt passed to clang, or'
+    '-Wl,--save-temps=import and -Wl,--thinlto-emit-index-files passed to '
+    'clang if the lld performed ThinLTO.')
 
 FLAGS = flags.FLAGS
 
@@ -118,6 +123,14 @@ class TrainingIRExtractor:
   def input_obj(self):
     return os.path.join(self.obj_base_dir(), self._obj_relative_path)
 
+  def lld_src_bc(self):
+    return os.path.join(self._obj_base_dir,
+                        self._obj_relative_path + '.3.import.bc')
+
+  def lld_src_thinlto(self):
+    return os.path.join(self._obj_base_dir,
+                        self._obj_relative_path + '.thinlto.bc')
+
   def dest_dir(self):
     return os.path.join(self.output_base_dir(),
                         os.path.dirname(self._obj_relative_path))
@@ -148,8 +161,8 @@ class TrainingIRExtractor:
         self.input_obj(), '/dev/null'
     ]
 
-  def extract(self, llvm_objcopy_path: str, cmd_filter: str,
-              is_thinlto: bool) -> Optional[str]:
+  def _extract_clang_artifacts(self, llvm_objcopy_path: str, cmd_filter: str,
+                               is_thinlto: bool) -> Optional[str]:
     """Run llvm-objcopy to extract the .bc and command line."""
     if not os.path.exists(self.input_obj()):
       logging.info('%s does not exist.', self.input_obj())
@@ -183,6 +196,36 @@ class TrainingIRExtractor:
             os.path.exists(self.bc_file()) and
             (not is_thinlto or os.path.exists(self.thinlto_index_file())))
     return self.relative_output_path()
+
+  def _extract_lld_artifacts(self) -> Optional[str]:
+    """Extract the .bc file with ThinLTO index from an lld ThinLTO invocation.
+    """
+    if not os.path.exists(self.lld_src_bc()):
+      logging.info('%s does not exist.', self.lld_src_bc())
+      return None
+    if not os.path.exists(self.lld_src_thinlto()):
+      logging.info('%s does not exist.', self.lld_src_thinlto())
+      return None
+    os.makedirs(self.dest_dir(), exist_ok=True)
+
+    # Copy over the files
+    shutil.copy(self.lld_src_bc(), self.bc_file())
+    shutil.copy(self.lld_src_thinlto(), self.thinlto_index_file())
+
+    assert os.path.exists(self.bc_file())
+    assert os.path.exists(self.thinlto_index_file())
+    return self._obj_relative_path
+
+  def extract(self,
+              llvm_objcopy_path: Optional[str] = None,
+              cmd_filter: Optional[str] = None,
+              thinlto_build: Optional[str] = None) -> Optional[str]:
+    if thinlto_build == 'lld':
+      return self._extract_lld_artifacts()
+    return self._extract_clang_artifacts(
+        llvm_objcopy_path=llvm_objcopy_path,
+        cmd_filter=cmd_filter,
+        is_thinlto=thinlto_build == 'clang')
 
 
 def convert_compile_command_to_objectfile(command: Dict[str, str],
@@ -232,6 +275,25 @@ def load_from_lld_params(params_array: List[str], obj_base_dir: str,
   return [make_obj(obj_file) for obj_file in just_obj_paths]
 
 
+def load_for_lld_thinlto(obj_base_dir: str,
+                         output_dir: str) -> List[TrainingIRExtractor]:
+  # .3.import.bc is the suffix attached to post-merge-pre-opt ('postimport')
+  # IR bitcode saved by lld. It is hardcoded into lld. ThinLTO index files
+  # are also emitted next to the postimport bitcode, with the suffix
+  # .thinlto.bc instead
+  paths = [str(p) for p in pathlib.Path(obj_base_dir).glob('**/*.3.import.bc')]
+
+  def make_spec(obj_file: str):
+    return TrainingIRExtractor(
+        # Cut away .3.import.bc
+        obj_relative_path=os.path.relpath(obj_file, start=obj_base_dir)[:-12],
+        output_base_dir=output_dir,
+        obj_base_dir=obj_base_dir)
+
+  # Last line is a newline char
+  return [make_spec(path) for path in paths]
+
+
 # This is here just for readability, lint complains if the pooling expression is
 # over 3 lines; and it needs to be a non-local so it may be pickled.
 def extract_artifacts(obj: TrainingIRExtractor) -> Optional[str]:
@@ -242,9 +304,16 @@ def extract_artifacts(obj: TrainingIRExtractor) -> Optional[str]:
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
-  flags.mark_flags_as_required(['output_dir', 'input'])
+  flags.mark_flags_as_required(['output_dir'])
+
   objs = []
-  if FLAGS.input_type == 'json':
+  if FLAGS.input is None:
+    if FLAGS.thinlto_build == 'lld':
+      objs = load_for_lld_thinlto(FLAGS.obj_base_dir, FLAGS.output_dir)
+    else:
+      logging.error('Input flag not provided')
+      raise ValueError
+  elif FLAGS.input_type == 'json':
     with open(FLAGS.input, encoding='utf-8') as f:
       objs = load_from_compile_commands(json.load(f), FLAGS.output_dir)
   elif FLAGS.input_type == 'params':

--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -159,7 +159,7 @@ class ExtractIrTest(absltest.TestCase):
     outdir = self.create_tempdir()
     obj = extract_ir.load_for_lld_thinlto(outer.full_path, outdir.full_path)
     for i, o in enumerate(sorted(obj, key=lambda x: x._obj_relative_path)):
-      mod_path = o.extract(thinlto_build='lld')
+      mod_path = o.extract(thinlto_build='local')
       self.assertEqual(mod_path, f'nest/{i + 1:d}')
     self.assertTrue(os.path.exists(os.path.join(outdir.full_path, 'nest/1.bc')))
     self.assertTrue(os.path.exists(os.path.join(outdir.full_path, 'nest/2.bc')))


### PR DESCRIPTION
New flag: `is_lld_thinlto` will auto-find the files generated from lld and copy them over