### PR TITLE
Add yapf to CI and dev dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,6 @@ jobs:
       - name: Check License Header
         run: |
           ./check-license.sh
+      - name: yapf formatting check
+        run: |
+          yapf . -drp

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@
 pytype==2022.06.06
 pylint==2.14.1
 pytest==7.1.2
+yapf==0.32.0


### PR DESCRIPTION
Since we are now using yapf to format the repository, it makes sense to
have yapf in the development requirements. This commit also adds a yapf
format check to the CI to ensure that all new code changes are properly
formatted.