### PR TITLE
Make the tensorboard data interval adjustable

### DIFF
--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -92,7 +92,7 @@ class TrainerTest(tf.test.TestCase):
         tf.compat.v1.train.AdamOptimizer(),
         num_outer_dims=2)
     test_trainer = trainer.Trainer(
-        root_dir=self.get_temp_dir(), agent=test_agent)
+        root_dir=self.get_temp_dir(), agent=test_agent, summary_log_interval=1)
     self.assertEqual(0, test_trainer._global_step.numpy())
 
     dataset_iter = _create_test_data(batch_size=3, sequence_length=3)


### PR DESCRIPTION
Currently, all of the tensorboard variables get updated every
single iteration. This is quite costly in terms of performance. I'm
seeing about a 25% performance improvement by just running this once
every 100 iterations instead of running it every iteration. The data
showing up in tensorboard will definitely be more sparse, but when
running everything locally, it seems to all appear just fine, and I'm not sure
getting data down to the iteration level is quite necessary, especially
given the large performance penalty.

I implemented this as an optional flag that can be passed from the command
line with what I believe is a reasonable default (once every 100 iterations), 
so it can be easily adjusted by the user if necessary while also being
a completely reasonable default for good tensorboard data/little
performance loss.