### PR TITLE
Replace module_paths with corpus_description.json

### DIFF
--- a/compiler_opt/rl/constant.py
+++ b/compiler_opt/rl/constant.py
@@ -23,6 +23,9 @@ BASE_MODULE_DIR = 'compiler_opt.rl'
 # Delta to add when computing reward.
 DELTA = 0.01
 
+# Default of global_command_override in corpus_description.json
+UNSPECIFIED_OVERRIDE = ['<UNSPECIFIED>']
+
 
 @gin.constants_from_enum
 class AgentName(enum.Enum):

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -37,19 +37,19 @@ def build_modulespecs_from_datapath(
 ) -> List[ModuleSpec]:
   # TODO: (b/233935329) Per-corpus *fdo profile paths can be read into
   # {additional|delete}_flags here
-  metadata: Dict[str, any] = _load_metadata(
-      os.path.join(data_path, 'metadata.json'))
-  module_paths = metadata['modules']
+  corpus_description: Dict[str, any] = _load_corpus_description(
+      os.path.join(data_path, 'corpus_description.json'))
+  module_paths = corpus_description['modules']
   if len(module_paths) == 0:
-    raise ValueError(f'{data_path}\'s metadata contains no modules.')
+    raise ValueError(f'{data_path}\'s corpus_description contains no modules.')
 
-  has_thinlto: bool = metadata['has_thinlto']
+  has_thinlto: bool = corpus_description['has_thinlto']
 
-  # Future: cmd_override could have per-module overrides if needed
-  if 'global_command_override' in metadata:
-    if metadata['global_command_override'] == ['Please', 'fill', 'options']:
-      raise ValueError('global_command_override in metadata.json not filled.')
-    cmd_override = tuple(metadata['global_command_override'])
+  if 'global_command_override' in corpus_description:
+    if corpus_description['global_command_override'] == ['<UNSPECIFIED>']:
+      raise ValueError(
+          'global_command_override in corpus_description.json not filled.')
+    cmd_override = tuple(corpus_description['global_command_override'])
     if len(additional_flags) > 0:
       logging.warning('Additional flags are specified together with override.')
     if len(delete_flags) > 0:
@@ -72,8 +72,8 @@ def build_modulespecs_from_datapath(
   return module_specs
 
 
-def _load_metadata(metadata_path: str) -> Dict[str, any]:
-  with open(metadata_path, 'r', encoding='utf-8') as f:
+def _load_corpus_description(corpus_description_path: str) -> Dict[str, any]:
+  with open(corpus_description_path, 'r', encoding='utf-8') as f:
     return json.load(f)
 
 

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -21,6 +21,8 @@ from typing import List, Dict, Tuple, Any
 import json
 import os
 
+from compiler_opt.tools import extract_ir
+
 
 @dataclass(frozen=True)
 class ModuleSpec:
@@ -46,7 +48,8 @@ def build_modulespecs_from_datapath(
   has_thinlto: bool = corpus_description['has_thinlto']
 
   if 'global_command_override' in corpus_description:
-    if corpus_description['global_command_override'] == ['<UNSPECIFIED>']:
+    if corpus_description[
+        'global_command_override'] == extract_ir.UNSPECIFIED_OVERRIDE:
       raise ValueError(
           'global_command_override in corpus_description.json not filled.')
     cmd_override = tuple(corpus_description['global_command_override'])

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -16,7 +16,7 @@
 
 from absl import logging
 from dataclasses import dataclass
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Any
 
 import json
 import os
@@ -37,7 +37,7 @@ def build_modulespecs_from_datapath(
 ) -> List[ModuleSpec]:
   # TODO: (b/233935329) Per-corpus *fdo profile paths can be read into
   # {additional|delete}_flags here
-  corpus_description: Dict[str, any] = _load_corpus_description(
+  corpus_description: Dict[str, Any] = _load_corpus_description(
       os.path.join(data_path, 'corpus_description.json'))
   module_paths = corpus_description['modules']
   if len(module_paths) == 0:
@@ -72,7 +72,7 @@ def build_modulespecs_from_datapath(
   return module_specs
 
 
-def _load_corpus_description(corpus_description_path: str) -> Dict[str, any]:
+def _load_corpus_description(corpus_description_path: str) -> Dict[str, Any]:
   with open(corpus_description_path, 'r', encoding='utf-8') as f:
     return json.load(f)
 

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -336,19 +336,20 @@ def main(argv):
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written
   if FLAGS.thinlto_build == 'local':
-    metadata = {'global_command_override': ['Please', 'fill', 'options']}
+    corpus_description = {'global_command_override': ['<UNSPECIFIED>']}
   else:
-    metadata = {}
+    corpus_description = {}
 
-  metadata.update({
+  corpus_description.update({
       'has_thinlto': FLAGS.thinlto_build is not None,
       'modules': [path for path in relative_output_paths if path is not None]
   })
 
   with open(
-      os.path.join(FLAGS.output_dir, 'metadata.json'), 'w',
+      os.path.join(FLAGS.output_dir, 'corpus_description.json'),
+      'w',
       encoding='utf-8') as f:
-    json.dump(metadata, f, indent=2)
+    json.dump(corpus_description, f, indent=2)
 
     logging.info('Converted %d files out of %d',
                  len(objs) - relative_output_paths.count(None), len(objs))

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -44,8 +44,7 @@ from absl import app
 from absl import flags
 from absl import logging
 
-# Default of global_command_override in corpus_description.json
-UNSPECIFIED_OVERRIDE = ['<UNSPECIFIED>']
+from compiler_opt.rl import constant
 
 flags.DEFINE_string(
     'input', None,
@@ -339,7 +338,9 @@ def main(argv):
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written
   if FLAGS.thinlto_build == 'local':
-    corpus_description = {'global_command_override': UNSPECIFIED_OVERRIDE}
+    corpus_description = {
+        'global_command_override': constant.UNSPECIFIED_OVERRIDE
+    }
   else:
     corpus_description = {}
 

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -44,6 +44,9 @@ from absl import app
 from absl import flags
 from absl import logging
 
+# Default of global_command_override in corpus_description.json
+UNSPECIFIED_OVERRIDE = ['<UNSPECIFIED>']
+
 flags.DEFINE_string(
     'input', None,
     'Input file - either compile_commands.json or a linker parameter list')
@@ -336,7 +339,7 @@ def main(argv):
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written
   if FLAGS.thinlto_build == 'local':
-    corpus_description = {'global_command_override': ['<UNSPECIFIED>']}
+    corpus_description = {'global_command_override': UNSPECIFIED_OVERRIDE}
   else:
     corpus_description = {}
 

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -156,7 +156,8 @@ def main(_):
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel
   sizes_and_specs = [
-      (os.path.getsize(m.name + '.bc'), i) for i, m in enumerate(module_specs)
+      (os.path.getsize(os.path.join(_DATA_PATH.value, m.name) + '.bc'), i)
+      for i, m in enumerate(module_specs)
   ]
   sizes_and_specs.sort(reverse=True)
   module_specs = [module_specs[i] for _, i in sizes_and_specs]

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -67,7 +67,7 @@ class GenerateDefaultTraceTest(absltest.TestCase):
     module_names = ['a', 'b', 'c', 'd']
 
     with tf.io.gfile.GFile(
-        os.path.join(tmp_dir.full_path, 'metadata.json'), 'w') as f:
+        os.path.join(tmp_dir.full_path, 'corpus_description.json'), 'w') as f:
       json.dump({'modules': module_names, 'has_thinlto': False}, f)
 
     for module_name in module_names:

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for generate_default_trace."""
-
+import json
 import os
 from unittest import mock
 
@@ -67,8 +67,8 @@ class GenerateDefaultTraceTest(absltest.TestCase):
     module_names = ['a', 'b', 'c', 'd']
 
     with tf.io.gfile.GFile(
-        os.path.join(tmp_dir.full_path, 'module_paths'), 'w') as f:
-      f.write('\n'.join(module_names))
+        os.path.join(tmp_dir.full_path, 'metadata.json'), 'w') as f:
+      json.dump({'modules': module_names, 'has_thinlto': False}, f)
 
     for module_name in module_names:
       with tf.io.gfile.GFile(


### PR DESCRIPTION
- This adds 'global_command_override' functionality for lld-thinlto corpora, exposed in metadata.json
- Setting the above in the corpus_description.json file will default the runners to using that as the base command, rather than looking for a .cmd file