### PR TITLE
Minor fixes

### DIFF
--- a/check-license.sh
+++ b/check-license.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,27 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 
 exitcode=0
-for fname in `find . -name "*.py"`; 
-do
-  diff -q <(head -14 $fname) <(cat license-header.txt) > /dev/null
-  if [ $? -ne 0 ]
+
+check_license () {
+  HEADER=$(head -1 $1)
+  if [[ $HEADER == \#!* ]] # Ignore shebang line
   then
-    echo "$fname does not have license header. Please copy and paste ./license-header.txt"
+    HEADER=$(head -$3 $1 | sed 1d)
+  else
+    HEADER=$(head -$(($3 - 1)) $fname)
+  fi
+  if [[ "$HEADER" != "$2" ]]
+  then
+    echo "$1 does not have license header. Please copy and paste ./license-header.txt"
     exitcode=1
   fi
+}
+
+for fname in `find . -name "*.py"`;
+do
+  check_license $fname "$(cat license-header.txt)" 15
 done
 
-for fname in `find . -name "*.sh"`; 
+for fname in `find . -name "*.sh"`;
 do
-  diff -q <(head -13 $fname) <(tail -13 license-header.txt) > /dev/null
-  if [ $? -ne 0 ]
-  then
-    echo "$fname does not have license header. Please copy and paste ./license-header.txt"
-    exitcode=1
-  fi
+  check_license $fname "$(tail -13 license-header.txt)" 14
 done
 
 exit ${exitcode}
+

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -125,4 +125,8 @@ def _load_and_parse_command(
 
   cmdline.extend(additional_flags)
 
+  # The options read from a .cmd file must be run with -cc1
+  if not cmd_override and cmdline[0] != '-cc1':
+    cmdline = ['-cc1'] + cmdline
+
   return cmdline

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -127,6 +127,6 @@ def _load_and_parse_command(
 
   # The options read from a .cmd file must be run with -cc1
   if not cmd_override and cmdline[0] != '-cc1':
-    cmdline = ['-cc1'] + cmdline
+    raise ValueError('-cc1 flag not present in .cmd file.')
 
   return cmdline

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -109,6 +109,15 @@ class CommandParsingTest(tf.test.TestCase):
             cmd_override=cmd_override),
         ['-fix-all-bugs', '-x', 'ir', 'this!path#cant$exist/hi.bc'])
 
+  def test_add_cc1(self):
+    data = ['-fix-all-bugs', '-xyz']
+    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
+    module_path = argfile.full_path[:-4]
+    self.assertEqual(
+        corpus._load_and_parse_command(
+            module_path=module_path, has_thinlto=False),
+        ['-cc1', '-fix-all-bugs', '-xyz', '-x', 'ir', module_path + '.bc'])
+
 
 class ModuleSpecTest(tf.test.TestCase):
 
@@ -137,8 +146,9 @@ class ModuleSpecTest(tf.test.TestCase):
                      ('-cc1', '-x', 'ir', tempdir.full_path + '/1.bc', '-add'))
 
     self.assertEqual(ms2.name, '2')
-    self.assertEqual(ms2.exec_cmd,
-                     ('-O3', '-x', 'ir', tempdir.full_path + '/2.bc', '-add'))
+    self.assertEqual(
+        ms2.exec_cmd,
+        ('-cc1', '-O3', '-x', 'ir', tempdir.full_path + '/2.bc', '-add'))
 
   def test_get_with_thinlto(self):
     corpus_description = {'modules': ['1', '2'], 'has_thinlto': True}
@@ -168,7 +178,7 @@ class ModuleSpecTest(tf.test.TestCase):
 
     self.assertEqual(ms2.name, '2')
     self.assertEqual(ms2.exec_cmd,
-                     ('-x', 'ir', tempdir.full_path + '/2.bc',
+                     ('-cc1', '-x', 'ir', tempdir.full_path + '/2.bc',
                       '-fthinlto-index=' + tempdir.full_path + '/2.thinlto.bc',
                       '-mllvm', '-thinlto-assume-merged', '-add'))
 

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -109,14 +109,15 @@ class CommandParsingTest(tf.test.TestCase):
             cmd_override=cmd_override),
         ['-fix-all-bugs', '-x', 'ir', 'this!path#cant$exist/hi.bc'])
 
-  def test_add_cc1(self):
+  def test_cc1_exists(self):
     data = ['-fix-all-bugs', '-xyz']
     argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
     module_path = argfile.full_path[:-4]
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path, has_thinlto=False),
-        ['-cc1', '-fix-all-bugs', '-xyz', '-x', 'ir', module_path + '.bc'])
+    self.assertRaises(
+        ValueError,
+        corpus._load_and_parse_command,
+        module_path=module_path,
+        has_thinlto=False)
 
 
 class ModuleSpecTest(tf.test.TestCase):
@@ -134,7 +135,7 @@ class ModuleSpecTest(tf.test.TestCase):
     tempdir.create_file('1.bc')
     tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
     tempdir.create_file('2.bc')
-    tempdir.create_file('2.cmd', content='\0'.join(['-O3']))
+    tempdir.create_file('2.cmd', content='\0'.join(['-cc1', '-O3']))
 
     ms_list = corpus.build_modulespecs_from_datapath(
         tempdir.full_path, additional_flags=('-add',))
@@ -161,7 +162,8 @@ class ModuleSpecTest(tf.test.TestCase):
         '1.cmd', content='\0'.join(['-cc1', '-fthinlto-index=xyz']))
     tempdir.create_file('2.bc')
     tempdir.create_file('2.thinlto.bc')
-    tempdir.create_file('2.cmd', content='\0'.join(['-fthinlto-index=abc']))
+    tempdir.create_file(
+        '2.cmd', content='\0'.join(['-cc1', '-fthinlto-index=abc']))
 
     ms_list = corpus.build_modulespecs_from_datapath(
         tempdir.full_path,

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -165,13 +165,19 @@ def create_sequence_example_dataset_fn(
   def _sequence_example_dataset_fn(sequence_examples):
     # Data collector returns empty strings for corner cases, filter them out
     # here.
-    dataset = (
-        tf.data.Dataset.from_tensor_slices(sequence_examples).filter(
-            lambda string: tf.strings.length(string) > 0).map(parser_fn).filter(
-                lambda traj: tf.size(traj.reward) > 2).unbatch().batch(
-                    train_sequence_length, drop_remainder=True).cache().shuffle(
-                        trajectory_shuffle_buffer_size).batch(
-                            batch_size, drop_remainder=True))
+    # yapf: disable - Looks better hand formatted
+    dataset = (tf.data.Dataset
+                .from_tensor_slices(sequence_examples)
+                .filter(lambda string: tf.strings.length(string) > 0)
+                .map(parser_fn)
+                .filter(lambda traj: tf.size(traj.reward) > 2)
+                .unbatch()
+                .batch(train_sequence_length, drop_remainder=True)
+                .cache()
+                .shuffle(trajectory_shuffle_buffer_size)
+                .batch(batch_size, drop_remainder=True)
+               )
+    # yapf: enable
     return dataset
 
   return _sequence_example_dataset_fn

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -227,6 +227,8 @@ class TrainingIRExtractor:
               llvm_objcopy_path: Optional[str] = None,
               cmd_filter: Optional[str] = None,
               thinlto_build: Optional[str] = None) -> Optional[str]:
+    if self._obj_relative_path is None:
+      return None
     if thinlto_build == 'local':
       return self._extract_lld_artifacts()
     return self._extract_clang_artifacts(
@@ -241,7 +243,11 @@ def convert_compile_command_to_objectfile(command: Dict[str, str],
   cmd = command['command']
 
   cmd_parts = cmd.split()
-  obj_index = cmd_parts.index('-o') + 1
+  try:
+    obj_index = cmd_parts.index('-o') + 1
+  except ValueError:
+    logging.info('Command has no -o option: %s', cmd)
+    return TrainingIRExtractor(None, None, None)
   obj_rel_path = cmd_parts[obj_index]
   # TODO(mtrofin): is the obj_base_dir correct for thinlto index bc files?
   return TrainingIRExtractor(

--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -34,12 +34,16 @@ class ExtractIrTest(absltest.TestCase):
             'command': '-cc1 -c /some/path/lib/foo/bar.cc -o lib/bar.o',
             'file': '/some/path/lib/foo/bar.cc'
         }, '/corpus/destination/path')
+    self.assertIsNotNone(obj)
+    # pytype: disable=attribute-error
+    # Pytype complains about obj being None
     self.assertEqual(obj.input_obj(), '/output/directory/lib/bar.o')
     self.assertEqual(obj.relative_output_path(), 'lib/bar.o')
     self.assertEqual(obj.cmd_file(), '/corpus/destination/path/lib/bar.o.cmd')
     self.assertEqual(obj.bc_file(), '/corpus/destination/path/lib/bar.o.bc')
     self.assertEqual(obj.thinlto_index_file(),
                      '/corpus/destination/path/lib/bar.o.thinlto.bc')
+    # pytype: enable=attribute-error
 
   def test_arr_conversion(self):
     res = extract_ir.load_from_compile_commands([{

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -77,7 +77,7 @@ class GenerateDefaultTraceTest(absltest.TestCase):
 
       with tf.io.gfile.GFile(
           os.path.join(tmp_dir.full_path, module_name + '.cmd'), 'w') as f:
-        f.write(module_name)
+        f.write('-cc1')
 
     mock_compilation_runner = MockCompilationRunner()
     mock_get_runner.return_value = mock_compilation_runner


### PR DESCRIPTION
- ensure the '-cc1' flag exists for commands extracted from .cmd files, as it is required
- disabled yapf formatting on data_reader's dataset builder
- gracefully handle when a compile_command doesn't have the -o option
- check-license.sh now ignores shebang lines