### PR TITLE
Add Corpus abstraction & sorting w/ size

### DIFF
--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ModuleSpec definition and utility command line parsing functions."""
-import itertools
 import random
 import re
 
@@ -53,12 +52,12 @@ class Corpus:
   @classmethod
   def from_module_specs(cls, module_specs: List[ModuleSpec]):
     """Construct a Corpus from module specs. Mostly for testing purposes."""
-    corp = cls.__new__(cls)  # Avoid calling __init__
-    super(cls, corp).__init__()
-    corp._module_specs = list(module_specs)  # Don't mutate the original list.
-    corp._module_specs.sort(key=lambda m: m.size, reverse=True)
-    corp.root_dir = None
-    return corp
+    cps = cls.__new__(cls)  # Avoid calling __init__
+    super(cls, cps).__init__()
+    cps._module_specs = list(module_specs)  # Don't mutate the original list.
+    cps._module_specs.sort(key=lambda m: m.size, reverse=True)
+    cps.root_dir = None
+    return cps
 
   def sample(self,
              k: int,

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -50,8 +50,7 @@ class Corpus:
           data_path=data_path,
           additional_flags=additional_flags,
           delete_flags=delete_flags)
-    self._root_dir = data_path
-    self.size = len(self._module_specs)
+    self.root_dir = data_path
     self._module_specs.sort(key=lambda m: m.size, reverse=True)
 
   def sample(self, k: int) -> List[ModuleSpec]:
@@ -68,6 +67,9 @@ class Corpus:
   def filter(self, p: re.Pattern):
     """Filters module specs, keeping those which match the provided pattern."""
     self._module_specs = [ms for ms in self._module_specs if p.match(ms.name)]
+
+  def __len__(self):
+    return len(self._module_specs)
 
 
 def _build_modulespecs_from_datapath(

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -19,7 +19,7 @@ import re
 
 from absl import logging
 from dataclasses import dataclass
-from typing import List, Dict, Tuple, Any, Optional
+from typing import List, Dict, Tuple, Any
 
 import json
 import os
@@ -42,17 +42,23 @@ class Corpus:
   def __init__(self,
                data_path: str,
                additional_flags: Tuple[str, ...] = (),
-               delete_flags: Tuple[str, ...] = (),
-               module_specs: Optional[List[ModuleSpec]] = None):
-    if module_specs is not None:
-      self._module_specs = module_specs
-    else:
-      self._module_specs = _build_modulespecs_from_datapath(
-          data_path=data_path,
-          additional_flags=additional_flags,
-          delete_flags=delete_flags)
+               delete_flags: Tuple[str, ...] = ()):
+    self._module_specs = _build_modulespecs_from_datapath(
+        data_path=data_path,
+        additional_flags=additional_flags,
+        delete_flags=delete_flags)
     self.root_dir = data_path
     self._module_specs.sort(key=lambda m: m.size, reverse=True)
+
+  @classmethod
+  def from_module_specs(cls, module_specs):
+    """Construct a Corpus from module specs. Mostly for testing purposes."""
+    corp = cls.__new__(cls)  # Avoid calling __init__
+    super(cls, corp).__init__()
+    corp._module_specs = list(module_specs)  # Don't mutate the original list.
+    corp._module_specs.sort(key=lambda m: m.size, reverse=True)
+    corp.root_dir = None
+    return corp
 
   def sample(self,
              k: int,

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -301,8 +301,8 @@ class CorpusTest(tf.test.TestCase):
 
   def test_bucket_sample_all(self):
     # Make sure we can sample everything, even if it's not divisible by the
-    # internal `n` in sampler_bucket_round_robin
-    # Create corpus with a prime number of modules
+    # `n` in SamplerBucketRoundRobin.
+    # Create corpus with a prime number of modules.
     cps = corpus.Corpus.from_module_specs(
         module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(101)])
 
@@ -312,8 +312,19 @@ class CorpusTest(tf.test.TestCase):
           k=101, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
       self.assertLen(sample, 101)
       for idx, s in enumerate(sample):
-        # Each bucket should be size 5, since n=20 in the sampler
+        # Since everything is sampled, it should be in perfect order.
         self.assertEqual(s.size, 100 - idx)
+
+  def test_bucket_sample_small(self):
+    # Make sure we can sample even when k < n.
+    cps = corpus.Corpus.from_module_specs(
+        module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(100)])
+
+    # Try all 19 possible values 0 < i < n
+    for i in range(1, 20):
+      sample = cps.sample(
+          k=i, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
+      self.assertLen(sample, i)
 
 
 if __name__ == '__main__':

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -251,14 +251,12 @@ class CorpusTest(tf.test.TestCase):
     self.assertEqual(len(corp), 1)
 
   def test_sample(self):
-    corp = corpus.Corpus(
-        '',
-        module_specs=[
-            corpus.ModuleSpec(name='smol', size=1),
-            corpus.ModuleSpec(name='middle', size=200),
-            corpus.ModuleSpec(name='largest', size=500),
-            corpus.ModuleSpec(name='small', size=100)
-        ])
+    corp = corpus.Corpus.from_module_specs(module_specs=[
+        corpus.ModuleSpec(name='smol', size=1),
+        corpus.ModuleSpec(name='middle', size=200),
+        corpus.ModuleSpec(name='largest', size=500),
+        corpus.ModuleSpec(name='small', size=100)
+    ])
     sample = corp.sample(4, sort=True)
     self.assertLen(sample, 4)
     self.assertEqual(sample[0].name, 'largest')
@@ -267,14 +265,12 @@ class CorpusTest(tf.test.TestCase):
     self.assertEqual(sample[3].name, 'smol')
 
   def test_filter(self):
-    corp = corpus.Corpus(
-        '',
-        module_specs=[
-            corpus.ModuleSpec(name='smol', size=1),
-            corpus.ModuleSpec(name='largest', size=500),
-            corpus.ModuleSpec(name='middle', size=200),
-            corpus.ModuleSpec(name='small', size=100)
-        ])
+    corp = corpus.Corpus.from_module_specs(module_specs=[
+        corpus.ModuleSpec(name='smol', size=1),
+        corpus.ModuleSpec(name='largest', size=500),
+        corpus.ModuleSpec(name='middle', size=200),
+        corpus.ModuleSpec(name='small', size=100)
+    ])
 
     corp.filter(re.compile(r'.+l'))
     sample = corp.sample(999, sort=True)
@@ -284,7 +280,8 @@ class CorpusTest(tf.test.TestCase):
     self.assertEqual(sample[2].name, 'smol')
 
   def test_sample_zero(self):
-    corp = corpus.Corpus('', module_specs=[corpus.ModuleSpec(name='smol')])
+    corp = corpus.Corpus.from_module_specs(
+        module_specs=[corpus.ModuleSpec(name='smol')])
 
     self.assertRaises(ValueError, corp.sample, 0)
     self.assertRaises(ValueError, corp.sample, -213213213)

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -293,7 +293,7 @@ class CorpusTest(tf.test.TestCase):
     # Try 32 times, for good measure.
     for i in range(32):
       sample = cps.sample(
-          k=20, sampler=corpus.sampler_bucket_round_robin, sort=True)
+          k=20, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
       self.assertLen(sample, 20)
       for idx, s in enumerate(sample):
         # Each bucket should be size 5, since n=20 in the sampler
@@ -309,7 +309,7 @@ class CorpusTest(tf.test.TestCase):
     # Try 32 times, for good measure.
     for i in range(32):
       sample = cps.sample(
-          k=101, sampler=corpus.sampler_bucket_round_robin, sort=True)
+          k=101, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
       self.assertLen(sample, 101)
       for idx, s in enumerate(sample):
         # Each bucket should be size 5, since n=20 in the sampler

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -259,7 +259,8 @@ class CorpusTest(tf.test.TestCase):
             corpus.ModuleSpec(name='largest', size=500),
             corpus.ModuleSpec(name='small', size=100)
         ])
-    sample = corp.sample(4)
+    sample = corp.sample(4, sort=True)
+    self.assertLen(sample, 4)
     self.assertEqual(sample[0].name, 'largest')
     self.assertEqual(sample[1].name, 'middle')
     self.assertEqual(sample[2].name, 'small')
@@ -276,7 +277,8 @@ class CorpusTest(tf.test.TestCase):
         ])
 
     corp.filter(re.compile(r'.+l'))
-    sample = corp.sample(999)
+    sample = corp.sample(999, sort=True)
+    self.assertLen(sample, 3)
     self.assertEqual(sample[0].name, 'middle')
     self.assertEqual(sample[1].name, 'small')
     self.assertEqual(sample[2].name, 'smol')

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -244,20 +244,20 @@ class CorpusTest(tf.test.TestCase):
     tempdir.create_file('1.bc')
     tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
 
-    corp = corpus.Corpus(tempdir.full_path, additional_flags=('-add',))
+    cps = corpus.Corpus(tempdir.full_path, additional_flags=('-add',))
     self.assertEqual(
         corpus._build_modulespecs_from_datapath(
-            tempdir.full_path, additional_flags=('-add',)), corp._module_specs)
-    self.assertEqual(len(corp), 1)
+            tempdir.full_path, additional_flags=('-add',)), cps._module_specs)
+    self.assertEqual(len(cps), 1)
 
   def test_sample(self):
-    corp = corpus.Corpus.from_module_specs(module_specs=[
+    cps = corpus.Corpus.from_module_specs(module_specs=[
         corpus.ModuleSpec(name='smol', size=1),
         corpus.ModuleSpec(name='middle', size=200),
         corpus.ModuleSpec(name='largest', size=500),
         corpus.ModuleSpec(name='small', size=100)
     ])
-    sample = corp.sample(4, sort=True)
+    sample = cps.sample(4, sort=True)
     self.assertLen(sample, 4)
     self.assertEqual(sample[0].name, 'largest')
     self.assertEqual(sample[1].name, 'middle')
@@ -265,34 +265,34 @@ class CorpusTest(tf.test.TestCase):
     self.assertEqual(sample[3].name, 'smol')
 
   def test_filter(self):
-    corp = corpus.Corpus.from_module_specs(module_specs=[
+    cps = corpus.Corpus.from_module_specs(module_specs=[
         corpus.ModuleSpec(name='smol', size=1),
         corpus.ModuleSpec(name='largest', size=500),
         corpus.ModuleSpec(name='middle', size=200),
         corpus.ModuleSpec(name='small', size=100)
     ])
 
-    corp.filter(re.compile(r'.+l'))
-    sample = corp.sample(999, sort=True)
+    cps.filter(re.compile(r'.+l'))
+    sample = cps.sample(999, sort=True)
     self.assertLen(sample, 3)
     self.assertEqual(sample[0].name, 'middle')
     self.assertEqual(sample[1].name, 'small')
     self.assertEqual(sample[2].name, 'smol')
 
   def test_sample_zero(self):
-    corp = corpus.Corpus.from_module_specs(
+    cps = corpus.Corpus.from_module_specs(
         module_specs=[corpus.ModuleSpec(name='smol')])
 
-    self.assertRaises(ValueError, corp.sample, 0)
-    self.assertRaises(ValueError, corp.sample, -213213213)
+    self.assertRaises(ValueError, cps.sample, 0)
+    self.assertRaises(ValueError, cps.sample, -213213213)
 
   def test_bucket_sample(self):
-    corp = corpus.Corpus.from_module_specs(
+    cps = corpus.Corpus.from_module_specs(
         module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(100)])
     # Odds of passing once by pure luck with random.sample: 1.779e-07
     # Try 32 times, for good measure.
     for i in range(32):
-      sample = corp.sample(
+      sample = cps.sample(
           k=20, sampler=corpus.sampler_bucket_round_robin, sort=True)
       self.assertLen(sample, 20)
       for idx, s in enumerate(sample):
@@ -303,12 +303,12 @@ class CorpusTest(tf.test.TestCase):
     # Make sure we can sample everything, even if it's not divisible by the
     # internal `n` in sampler_bucket_round_robin
     # Create corpus with a prime number of modules
-    corp = corpus.Corpus.from_module_specs(
+    cps = corpus.Corpus.from_module_specs(
         module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(101)])
 
     # Try 32 times, for good measure.
     for i in range(32):
-      sample = corp.sample(
+      sample = cps.sample(
           k=101, sampler=corpus.sampler_bucket_round_robin, sort=True)
       self.assertLen(sample, 101)
       for idx, s in enumerate(sample):

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -244,11 +244,11 @@ class CorpusTest(tf.test.TestCase):
     tempdir.create_file('1.bc')
     tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
 
+    corp = corpus.Corpus(tempdir.full_path, additional_flags=('-add',))
     self.assertEqual(
         corpus._build_modulespecs_from_datapath(
-            tempdir.full_path, additional_flags=('-add',)),
-        corpus.Corpus(tempdir.full_path,
-                      additional_flags=('-add',))._module_specs)
+            tempdir.full_path, additional_flags=('-add',)), corp._module_specs)
+    self.assertEqual(len(corp), 1)
 
   def test_sample(self):
     corp = corpus.Corpus(

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -107,7 +107,7 @@ class LocalDataCollector(data_collector.DataCollector):
       They will be reported using `tf.scalar.summary` by the trainer so these
       information is viewable in TensorBoard.
     """
-    sampled_modules = self._corpus.sample(k=self._num_modules)
+    sampled_modules = self._corpus.sample(k=self._num_modules, sort=False)
     results = self._schedule_jobs(policy_path, sampled_modules)
 
     def wait_for_termination():

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -85,7 +85,7 @@ class LocalDataCollector(data_collector.DataCollector):
     jobs = [(module_spec, policy_path, self._reward_stat_map[module_spec.name])
             for module_spec in sampled_modules]
 
-    # Naive load balancing.
+    # TODO: Issue #91. Naive load balancing.
     ret = []
     for i in range(len(jobs)):
       ret.append(self._worker_pool[i % len(self._worker_pool)].collect_data(

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -16,7 +16,6 @@
 
 import concurrent.futures
 import itertools
-import random
 import time
 from typing import Callable, Dict, Iterator, List, Tuple, Optional
 
@@ -34,7 +33,7 @@ class LocalDataCollector(data_collector.DataCollector):
 
   def __init__(
       self,
-      module_specs: List[corpus.ModuleSpec],
+      corp: corpus.Corpus,
       num_modules: int,
       worker_pool: List[compilation_runner.CompilationRunnerStub],
       parser: Callable[[List[str]], Iterator[trajectory.Trajectory]],
@@ -44,7 +43,7 @@ class LocalDataCollector(data_collector.DataCollector):
     # TODO(mtrofin): type exit_checker_ctor when we get typing.Protocol support
     super().__init__()
 
-    self._module_specs = module_specs
+    self._corpus = corp
     self._num_modules = num_modules
     self._parser = parser
     self._worker_pool = worker_pool
@@ -108,7 +107,7 @@ class LocalDataCollector(data_collector.DataCollector):
       They will be reported using `tf.scalar.summary` by the trainer so these
       information is viewable in TensorBoard.
     """
-    sampled_modules = random.sample(self._module_specs, k=self._num_modules)
+    sampled_modules = self._corpus.sample(k=self._num_modules)
     results = self._schedule_jobs(policy_path, sampled_modules)
 
     def wait_for_termination():

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -33,7 +33,7 @@ class LocalDataCollector(data_collector.DataCollector):
 
   def __init__(
       self,
-      corp: corpus.Corpus,
+      cps: corpus.Corpus,
       num_modules: int,
       worker_pool: List[compilation_runner.CompilationRunnerStub],
       parser: Callable[[List[str]], Iterator[trajectory.Trajectory]],
@@ -43,7 +43,7 @@ class LocalDataCollector(data_collector.DataCollector):
     # TODO(mtrofin): type exit_checker_ctor when we get typing.Protocol support
     super().__init__()
 
-    self._corpus = corp
+    self._corpus = cps
     self._num_modules = num_modules
     self._parser = parser
     self._worker_pool = worker_pool

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -116,8 +116,8 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          corp=corpus.Corpus(
-              '', module_specs=[corpus.ModuleSpec(name='dummy')] * 100),
+          corp=corpus.Corpus.from_module_specs(
+              module_specs=[corpus.ModuleSpec(name='dummy')] * 100),
           num_modules=9,
           worker_pool=lwp,
           parser=create_test_iterator_fn(),
@@ -178,8 +178,8 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          corp=corpus.Corpus(
-              '', module_specs=[corpus.ModuleSpec(name='dummy')] * 200),
+          corp=corpus.Corpus.from_module_specs(
+              module_specs=[corpus.ModuleSpec(name='dummy')] * 200),
           num_modules=4,
           worker_pool=lwp,
           parser=parser,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -116,7 +116,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          corp=corpus.Corpus.from_module_specs(
+          cps=corpus.Corpus.from_module_specs(
               module_specs=[corpus.ModuleSpec(name='dummy')] * 100),
           num_modules=9,
           worker_pool=lwp,
@@ -178,7 +178,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          corp=corpus.Corpus.from_module_specs(
+          cps=corpus.Corpus.from_module_specs(
               module_specs=[corpus.ModuleSpec(name='dummy')] * 200),
           num_modules=4,
           worker_pool=lwp,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -116,7 +116,8 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          module_specs=[corpus.ModuleSpec(name='dummy')] * 100,
+          corp=corpus.Corpus(
+              '', module_specs=[corpus.ModuleSpec(name='dummy')] * 100),
           num_modules=9,
           worker_pool=lwp,
           parser=create_test_iterator_fn(),
@@ -177,7 +178,8 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          module_specs=[corpus.ModuleSpec(name='dummy')] * 200,
+          corp=corpus.Corpus(
+              '', module_specs=[corpus.ModuleSpec(name='dummy')] * 200),
           num_modules=4,
           worker_pool=lwp,
           parser=parser,

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -99,9 +99,8 @@ def train_eval(agent_name=constant.AgentName.PPO,
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 
   logging.info('Loading module specs from corpus.')
-  corp = corpus.Corpus(
-      FLAGS.data_path, problem_config.flags_to_add(),
-      problem_config.flags_to_delete())
+  corp = corpus.Corpus(FLAGS.data_path, problem_config.flags_to_add(),
+                       problem_config.flags_to_delete())
   logging.info('Done loading module specs from corpus.')
 
   dataset_fn = data_reader.create_sequence_example_dataset_fn(

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -99,8 +99,8 @@ def train_eval(agent_name=constant.AgentName.PPO,
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 
   logging.info('Loading module specs from corpus.')
-  corp = corpus.Corpus(FLAGS.data_path, problem_config.flags_to_add(),
-                       problem_config.flags_to_delete())
+  cps = corpus.Corpus(FLAGS.data_path, problem_config.flags_to_add(),
+                      problem_config.flags_to_delete())
   logging.info('Done loading module specs from corpus.')
 
   dataset_fn = data_reader.create_sequence_example_dataset_fn(
@@ -135,7 +135,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
       count=FLAGS.num_workers,
       moving_average_decay_rate=moving_average_decay_rate) as worker_pool:
     data_collector = local_data_collector.LocalDataCollector(
-        corp=corp,
+        cps=cps,
         num_modules=num_modules,
         worker_pool=worker_pool,
         parser=sequence_example_iterator_fn,

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -99,7 +99,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
   saver = policy_saver.PolicySaver(policy_dict=policy_dict)
 
   logging.info('Loading module specs from corpus.')
-  module_specs = corpus.build_modulespecs_from_datapath(
+  corp = corpus.Corpus(
       FLAGS.data_path, problem_config.flags_to_add(),
       problem_config.flags_to_delete())
   logging.info('Done loading module specs from corpus.')
@@ -136,7 +136,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
       count=FLAGS.num_workers,
       moving_average_decay_rate=moving_average_decay_rate) as worker_pool:
     data_collector = local_data_collector.LocalDataCollector(
-        module_specs=module_specs,
+        corp=corp,
         num_modules=num_modules,
         worker_pool=worker_pool,
         parser=sequence_example_iterator_fn,

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -138,7 +138,7 @@ def main(_):
   config = registry.get_configuration()
 
   logging.info('Loading module specs from corpus.')
-  corp = corpus.Corpus(
+  cps = corpus.Corpus(
       _DATA_PATH.value,
       additional_flags=config.flags_to_add(),
       delete_flags=config.flags_to_delete())
@@ -146,11 +146,11 @@ def main(_):
 
   if _MODULE_FILTER.value:
     m = re.compile(_MODULE_FILTER.value)
-    corp.filter(m)
+    cps.filter(m)
 
   # Sampling if needed.
-  sampled_modules = int(len(corp) * _SAMPLING_RATE.value)
-  module_specs = corp.sample(k=sampled_modules, sort=True)
+  sampled_modules = int(len(cps) * _SAMPLING_RATE.value)
+  module_specs = cps.sample(k=sampled_modules, sort=True)
 
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -149,7 +149,7 @@ def main(_):
     corp.filter(m)
 
   # Sampling if needed.
-  sampled_modules = int(corp.size * _SAMPLING_RATE.value)
+  sampled_modules = int(len(corp) * _SAMPLING_RATE.value)
   module_specs = corp.sample(k=sampled_modules)
 
   # sort files by size, to process the large files upfront, hopefully while

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -150,16 +150,9 @@ def main(_):
 
   # Sampling if needed.
   sampled_modules = int(len(cps) * _SAMPLING_RATE.value)
-  module_specs = cps.sample(k=sampled_modules, sort=True)
-
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel
-  sizes_and_specs = [
-      (os.path.getsize(os.path.join(_DATA_PATH.value, m.name) + '.bc'), i)
-      for i, m in enumerate(module_specs)
-  ]
-  sizes_and_specs.sort(reverse=True)
-  module_specs = [module_specs[i] for _, i in sizes_and_specs]
+  module_specs = cps.sample(k=sampled_modules, sort=True)
 
   worker_count = (
       min(os.cpu_count(), _NUM_WORKERS.value)

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -18,7 +18,6 @@ import contextlib
 import functools
 import os
 import queue
-import random
 import re
 import subprocess
 from typing import Dict, List, Optional, Union, Tuple  # pylint:disable=unused-import
@@ -139,7 +138,7 @@ def main(_):
   config = registry.get_configuration()
 
   logging.info('Loading module specs from corpus.')
-  module_specs = corpus.build_modulespecs_from_datapath(
+  corp = corpus.Corpus(
       _DATA_PATH.value,
       additional_flags=config.flags_to_add(),
       delete_flags=config.flags_to_delete())
@@ -147,12 +146,11 @@ def main(_):
 
   if _MODULE_FILTER.value:
     m = re.compile(_MODULE_FILTER.value)
-    module_specs = [ms for ms in module_specs if m.match(ms.name)]
+    corp.filter(m)
 
   # Sampling if needed.
-  if _SAMPLING_RATE.value < 1:
-    sampled_modules = int(len(module_specs) * _SAMPLING_RATE.value)
-    module_specs = random.sample(module_specs, k=sampled_modules)
+  sampled_modules = int(corp.size * _SAMPLING_RATE.value)
+  module_specs = corp.sample(k=sampled_modules)
 
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -150,7 +150,7 @@ def main(_):
 
   # Sampling if needed.
   sampled_modules = int(len(corp) * _SAMPLING_RATE.value)
-  module_specs = corp.sample(k=sampled_modules)
+  module_specs = corp.sample(k=sampled_modules, sort=True)
 
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel


### PR DESCRIPTION
- Rather than pass around a list of module_specs, pass around a Corpus object instead
- Corpus has built in filter and sample method
- sample will sort by size descending, with the goal of optimizing compile order for time