### PR TITLE
Add reward_only to runners

### DIFF
--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -287,8 +287,6 @@ class CompilationRunner(Worker):
 
   @staticmethod
   def get_rewards(result: Dict) -> List[float]:
-    if len(result) == 0:
-      return []
     return [v[1] for v in result.values()]
 
   def collect_results(

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -230,11 +230,12 @@ class CompilationRunnerStub(metaclass=abc.ABCMeta):
   """The interface of a stub to CompilationRunner, for type checkers."""
 
   @abc.abstractmethod
-  def collect_results(self,
-                      module_spec: corpus.ModuleSpec,
-                      tf_policy_path: str,
-                      collect_default_result: bool,
-                      reward_only: bool = False) -> Tuple[Dict, Dict]:
+  def collect_results(
+      self,
+      module_spec: corpus.ModuleSpec,
+      tf_policy_path: str,
+      collect_default_result: bool,
+      reward_only: bool = False) -> Tuple[Optional[Dict], Optional[Dict]]:
     raise NotImplementedError()
 
   @abc.abstractmethod
@@ -290,11 +291,12 @@ class CompilationRunner(Worker):
       return []
     return [v[1] for v in result.values()]
 
-  def collect_results(self,
-                      module_spec: corpus.ModuleSpec,
-                      tf_policy_path: str,
-                      collect_default_result: bool,
-                      reward_only: bool = False) -> Tuple[Dict, Dict]:
+  def collect_results(
+      self,
+      module_spec: corpus.ModuleSpec,
+      tf_policy_path: str,
+      collect_default_result: bool,
+      reward_only: bool = False) -> Tuple[Optional[Dict], Optional[Dict]]:
     """Collect data for the given IR file and policy.
 
     Args:

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -164,6 +164,29 @@ class CompilationRunnerTest(tf.test.TestCase):
 
   @mock.patch(constant.BASE_MODULE_DIR +
               '.compilation_runner.CompilationRunner._compile_fn')
+  def test_reward_only(self, mock_compile_fn):
+    mock_compile_fn.side_effect = _mock_compile_fn
+    runner = compilation_runner.CompilationRunner(
+        moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
+    default_result, policy_result = runner.collect_results(
+        module_spec=corpus.ModuleSpec(name='dummy'),
+        tf_policy_path='policy_path',
+        collect_default_result=True,
+        reward_only=True)
+    self.assertEqual(2, mock_compile_fn.call_count)
+
+    self.assertIsNotNone(default_result)
+    self.assertIsNotNone(policy_result)
+
+    self.assertEqual(
+        [_DEFAULT_REWARD],
+        compilation_runner.CompilationRunner.get_rewards(default_result))
+    self.assertEqual(
+        [_POLICY_REWARD],
+        compilation_runner.CompilationRunner.get_rewards(policy_result))
+
+  @mock.patch(constant.BASE_MODULE_DIR +
+              '.compilation_runner.CompilationRunner._compile_fn')
   def test_given_default_size(self, mock_compile_fn):
     mock_compile_fn.side_effect = _mock_compile_fn
     runner = compilation_runner.CompilationRunner(


### PR DESCRIPTION
- Will be useful for validation runner and generate default trace
- Adds a todo w.r.t. CompilationResult having odd asserts/redundant attributes

Part of #96 

(was #98 before I messed up my branch reset and GitHub took the opportunity to close it)