### PR TITLE
Prepare requirements for tflite

### DIFF
--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -45,9 +45,8 @@ class ConstantValueNetwork(network.Network):
 
     self._constant_output_val = constant_output_val
 
-  def call(self, observation, step_type=None, network_state=(), training=False):
+  def call(self, inputs, step_type=None, network_state=(), training=False):
     _ = (step_type, training)
-    shape = nest_utils.get_outer_array_shape(observation,
-                                             self._input_tensor_spec)
+    shape = nest_utils.get_outer_array_shape(inputs, self._input_tensor_spec)
     return tf.constant(
         self._constant_output_val, tf.float32, shape=shape), network_state

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,6 @@ filterwarnings =
 
 	# Not much to do about this, it's caused by gin
 	ignore:Using or importing the ABCs from 'collections':DeprecationWarning
+
+	# Issue #119
+	ignore:Encoding a StructuredValue with type tfp.distributions.Deterministic_ACTTypeSpec:UserWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,6 @@ grpcio==1.39.0
 gym==0.19.0
 h5py==3.6.0
 idna==3.2
-keras==2.7.0
-keras-preprocessing==1.1.2
 libclang==13.0.0
 markdown==3.3.4
 numpy==1.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-absl-py==0.11.0
+absl-py==1.0.0
 astunparse==1.6.3
 cachetools==4.2.2
 certifi==2021.5.30
@@ -20,7 +20,7 @@ h5py==3.6.0
 idna==3.2
 keras==2.7.0
 keras-preprocessing==1.1.2
-libclang==12.0.0
+libclang==13.0.0
 markdown==3.3.4
 numpy==1.22.1
 oauthlib==3.1.1
@@ -40,12 +40,12 @@ six==1.16.0
 tensorboard==2.7.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
-tensorflow==2.7.0
+tf-nightly==2.11.0.dev20220823
 tensorflow-estimator==2.7.0
 tensorflow-io-gcs-filesystem==0.23.1
 tensorflow-probability==0.15.0
 termcolor==1.1.0
-tf-agents==0.11.0
+tf-agents-nightly==0.14.0.dev20220823
 typing-extensions==4.0.1
 urllib3==1.26.6
 werkzeug==2.0.1


### PR DESCRIPTION
We need to get past TF 2.9, but 2.10 isn't released yet, and there are
compat issues between 2.10-RC1 and tfagents. The recommended approach is
to install nightlies of these.