### PR TITLE
Migrate to Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           if [ -z $ACT ]
           then 
-            _ver="[3.8, 3.9]"
+            _ver="['3.8', '3.9', '3.10']"
             _cache="1"
           else 
-            _ver="[3.8]"
+            _ver="['3.8']"
             _cache="0"
           fi
           echo "::set-output name=version_matrix::$_ver"

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,13 @@ filterwarnings =
 
 	# Issue #119
 	ignore:Encoding a StructuredValue with type tfp.distributions.Deterministic_ACTTypeSpec:UserWarning
+
+	# This warning stems from tensorflow and tf-agents and will presumably
+	# be fixed by them before v3.12
+	ignore:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning
+
+	# Also an issue internal to tensorflow
+	ignore:Call to deprecated create function .*Descriptor.*:DeprecationWarning
+
+	# Also internal to tensorflow
+	ignore:non-integer arguments to randrange.*:DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flatbuffers==2.0
 future==0.18.2
 gast==0.4.0
 gin==0.1.006
-gin-config==0.4.0
+gin-config==0.5.0
 google-auth-oauthlib==0.4.5
 google-auth==1.35.0
 google-pasta==0.2.0
@@ -23,7 +23,7 @@ markdown==3.3.4
 numpy==1.22.1
 oauthlib==3.1.1
 opt-einsum==3.3.0
-pillow==8.3.1
+pillow==9.2.0
 protobuf==3.17.3
 psutil==5.9.0
 pyasn1==0.4.8
@@ -32,7 +32,7 @@ pyglet==1.5.0
 requests==2.26.0
 requests-oauthlib==1.3.0
 rsa==4.7.2
-scipy==1.7.1
+scipy==1.7.2
 setuptools==57.4.0
 six==1.16.0
 tensorboard==2.7.0


### PR DESCRIPTION
This PR changes the Github CI to test against Python 3.9 and 3.10 instead of 3.8 and 3.9. Could be adjusted if we still want to support 3.8 though. Also adjusts the versions of some dependencies so that they are compatible with 3.10. There are a couple new deprecation warnings internal to tensorflow that I've excluded in the `pytest.ini`. Nothing super major and I'm guessing it will get fixed by the time anything gets even close to being deprecated.