### PR TITLE
Fix trainer only logging tensorboard data on summary_export_interval

### DIFF
--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -92,10 +92,7 @@ class TrainerTest(tf.test.TestCase):
         tf.compat.v1.train.AdamOptimizer(),
         num_outer_dims=2)
     test_trainer = trainer.Trainer(
-        root_dir=self.get_temp_dir(),
-        agent=test_agent,
-        summary_log_interval=1,
-        summary_export_interval=10)
+        root_dir=self.get_temp_dir(), agent=test_agent, summary_log_interval=10)
     self.assertEqual(0, test_trainer._global_step.numpy())
 
     dataset_iter = _create_test_data(batch_size=3, sequence_length=3)


### PR DESCRIPTION
In #62 I separated out the summary_interval variable to
summary_log_interval and summary_export_interval, assuming that
tensorboard only flushed everything to disk when the callable passed to
tf.summary.record_if was true while still allowing writing to the
buffers. However, this assumption turned out to be mistaken as anytime
summary_export_interval and summary_log_interval weren't both hit by the
current step, nothing would be logged, so data would only get logged
when summary_export_interval was hit. This patch fixes that by getting
rid of summary_export_interval and changing everything back to
summary_log_interval while gating the actual writing of the scalars
using tf.summary.should_record_summaries() to keep the performance gains
mentioned in #62.