### PR TITLE
Pass serialized policies to workers

### DIFF
--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -20,12 +20,13 @@ import json
 import os
 import signal
 import subprocess
+import tempfile
 import threading
 from typing import Dict, List, Optional, Tuple
 
 from absl import flags
 from compiler_opt.distributed.worker import Worker, WorkerFuture
-from compiler_opt.rl import constant
+from compiler_opt.rl import constant, policy_saver
 from compiler_opt.rl import corpus
 import tensorflow as tf
 
@@ -46,6 +47,38 @@ def _calculate_reward(policy: float, baseline: float) -> float:
 class RewardStat:
   default_reward: float
   moving_average_reward: float
+
+
+@dataclasses.dataclass(frozen=True)
+class Policy:
+  """Serialized mlgo policy, used to pass a policy to workers.
+
+  A policy has 2 components, both being file contents:
+    - the content of the output_spec.json file;
+    - the content of the tflite policy.
+  """
+
+  output_spec: bytes
+  policy: bytes
+
+  def to_filesystem(self, location: str):
+    os.makedirs(location, exist_ok=True)
+    output_sig = os.path.join(location, policy_saver.OUTPUT_SIGNATURE)
+    policy_path = os.path.join(location, policy_saver.TFLITE_MODEL_NAME)
+    with tf.io.gfile.GFile(output_sig, mode='wb') as f:
+      f.write(self.output_spec)
+    with tf.io.gfile.GFile(policy_path, mode='wb') as f:
+      f.write(self.policy)
+
+  @staticmethod
+  def from_filesystem(location: str):
+    output_sig = os.path.join(location, policy_saver.OUTPUT_SIGNATURE)
+    policy_path = os.path.join(location, policy_saver.TFLITE_MODEL_NAME)
+    with tf.io.gfile.GFile(output_sig, mode='rb') as f:
+      output_spec = f.read()
+    with tf.io.gfile.GFile(policy_path, mode='rb') as f:
+      policy = f.read()
+    return Policy(output_spec=output_spec, policy=policy)
 
 
 class DataClassJSONEncoder(json.JSONEncoder):
@@ -257,8 +290,10 @@ class CompilationRunnerStub(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def collect_data(
-      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
-      reward_stat: Optional[Dict[str, RewardStat]]
+      self,
+      module_spec: corpus.ModuleSpec,
+      policy: Optional[Policy] = None,
+      reward_stat: Optional[Dict[str, RewardStat]] = None
   ) -> WorkerFuture[CompilationResult]:
     raise NotImplementedError()
 
@@ -314,13 +349,15 @@ class CompilationRunner(Worker):
     self._cancellation_manager.resume_all_processes()
 
   def collect_data(
-      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
-      reward_stat: Optional[Dict[str, RewardStat]]) -> CompilationResult:
+      self,
+      module_spec: corpus.ModuleSpec,
+      policy: Optional[Policy] = None,
+      reward_stat: Optional[Dict[str, RewardStat]] = None) -> CompilationResult:
     """Collect data for the given IR file and policy.
 
     Args:
       module_spec: a ModuleSpec.
-      tf_policy_path: path to the tensorflow policy.
+      policy: serialized policy.
       reward_stat: reward stat of this module, None if unknown.
 
     Returns:
@@ -333,18 +370,24 @@ class CompilationRunner(Worker):
       compilation_runner.ProcessKilledException is passed through.
       ValueError if example under default policy and ml policy does not match.
     """
-    if reward_stat is None:
-      default_result = self.compile_fn(
-          module_spec, tf_policy_path='', reward_only=bool(tf_policy_path))
-      reward_stat = {
-          k: RewardStat(v[1], v[1]) for (k, v) in default_result.items()
-      }
+    with tempfile.TemporaryDirectory() as tempdir:
+      tf_policy_path = ''
+      if policy is not None:
+        tf_policy_path = os.path.join(tempdir, 'policy')
+        policy.to_filesystem(tf_policy_path)
 
-    if tf_policy_path:
-      policy_result = self.compile_fn(
-          module_spec, tf_policy_path, reward_only=False)
-    else:
-      policy_result = default_result
+      if reward_stat is None:
+        default_result = self.compile_fn(
+            module_spec, tf_policy_path='', reward_only=bool(tf_policy_path))
+        reward_stat = {
+            k: RewardStat(v[1], v[1]) for (k, v) in default_result.items()
+        }
+
+      if tf_policy_path:
+        policy_result = self.compile_fn(
+            module_spec, tf_policy_path, reward_only=False)
+      else:
+        policy_result = default_result
 
     sequence_example_list = []
     rewards = []

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -30,6 +30,7 @@ from google.protobuf import text_format  # pytype: disable=pyi-error
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import constant
 from compiler_opt.rl import corpus
+from compiler_opt.rl import policy_saver
 
 _DEFAULT_FEATURE_VALUE = 12
 _POLICY_FEATURE_VALUE = 34
@@ -91,7 +92,7 @@ def _mock_compile_fn(file_paths, tf_policy_path, reward_only):  # pylint: disabl
     return {'default': (sequence_example, native_size)}
 
 
-_mock_policy = compilation_runner.Policy(bytes(), bytes())
+_mock_policy = policy_saver.Policy(bytes(), bytes())
 
 
 class CompilationRunnerTest(tf.test.TestCase):

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -91,6 +91,9 @@ def _mock_compile_fn(file_paths, tf_policy_path, reward_only):  # pylint: disabl
     return {'default': (sequence_example, native_size)}
 
 
+_mock_policy = compilation_runner.Policy(bytes(), bytes())
+
+
 class CompilationRunnerTest(tf.test.TestCase):
 
   def assertListProtoEqual(self, a, b):
@@ -107,9 +110,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
     data = runner.collect_data(
-        module_spec=corpus.ModuleSpec(name='dummy'),
-        tf_policy_path='policy_path',
-        reward_stat=None)
+        module_spec=corpus.ModuleSpec(name='dummy'), policy=_mock_policy)
     self.assertEqual(2, mock_compile_fn.call_count)
 
     expected_example = _get_sequence_example_with_reward(
@@ -137,10 +138,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
-    data = runner.collect_data(
-        module_spec=corpus.ModuleSpec(name='dummy'),
-        tf_policy_path='',
-        reward_stat=None)
+    data = runner.collect_data(module_spec=corpus.ModuleSpec(name='dummy'))
     # One call when we ask for the default policy, because it can provide both
     # trace and default size.
     self.assertEqual(1, mock_compile_fn.call_count)
@@ -170,7 +168,7 @@ class CompilationRunnerTest(tf.test.TestCase):
 
     data = runner.collect_data(
         module_spec=corpus.ModuleSpec(name='dummy'),
-        tf_policy_path='policy_path',
+        policy=_mock_policy,
         reward_stat={
             'default':
                 compilation_runner.RewardStat(
@@ -207,7 +205,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     with self.assertRaisesRegex(subprocess.CalledProcessError, 'error'):
       _ = runner.collect_data(
           module_spec=corpus.ModuleSpec(name='dummy'),
-          tf_policy_path='policy_path',
+          policy=_mock_policy,
           reward_stat=None)
     self.assertEqual(1, mock_compile_fn.call_count)
 

--- a/compiler_opt/rl/data_collector.py
+++ b/compiler_opt/rl/data_collector.py
@@ -19,7 +19,7 @@ import time
 from typing import Dict, Iterator, Tuple, Sequence
 
 import numpy as np
-from compiler_opt.rl import compilation_runner
+from compiler_opt.rl import policy_saver
 from tf_agents.trajectories import trajectory
 
 # Deadline for data collection.
@@ -52,7 +52,7 @@ class DataCollector(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def collect_data(
-      self, policy: compilation_runner.Policy
+      self, policy: policy_saver.Policy
   ) -> Tuple[Iterator[trajectory.Trajectory], Dict[str, Dict[str, float]]]:
     """Collect data for a given policy.
 

--- a/compiler_opt/rl/data_collector.py
+++ b/compiler_opt/rl/data_collector.py
@@ -19,6 +19,7 @@ import time
 from typing import Dict, Iterator, Tuple, Sequence
 
 import numpy as np
+from compiler_opt.rl import compilation_runner
 from tf_agents.trajectories import trajectory
 
 # Deadline for data collection.
@@ -51,7 +52,7 @@ class DataCollector(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def collect_data(
-      self, policy_path: str
+      self, policy: compilation_runner.Policy
   ) -> Tuple[Iterator[trajectory.Trajectory], Dict[str, Dict[str, float]]]:
     """Collect data for a given policy.
 

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -27,6 +27,7 @@ from compiler_opt.distributed.local import buffered_scheduler
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import corpus
 from compiler_opt.rl import data_collector
+from compiler_opt.rl import policy_saver
 
 
 class LocalDataCollector(data_collector.DataCollector):
@@ -78,7 +79,7 @@ class LocalDataCollector(data_collector.DataCollector):
                  time.time() - t1)
 
   def _schedule_jobs(
-      self, policy: compilation_runner.Policy,
+      self, policy: policy_saver.Policy,
       sampled_modules: List[corpus.ModuleSpec]
   ) -> List[worker.WorkerFuture[compilation_runner.CompilationResult]]:
     # by now, all the pending work, which was signaled to cancel, must've
@@ -98,7 +99,7 @@ class LocalDataCollector(data_collector.DataCollector):
     return buffered_scheduler.schedule(work, self._worker_pool, buffer=10)
 
   def collect_data(
-      self, policy: compilation_runner.Policy
+      self, policy: policy_saver.Policy
   ) -> Tuple[Iterator[trajectory.Trajectory], Dict[str, Dict[str, float]]]:
     """Collect data for a given policy.
 

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -78,12 +78,13 @@ class LocalDataCollector(data_collector.DataCollector):
                  time.time() - t1)
 
   def _schedule_jobs(
-      self, policy_path: str, sampled_modules: List[corpus.ModuleSpec]
+      self, policy: compilation_runner.Policy,
+      sampled_modules: List[corpus.ModuleSpec]
   ) -> List[worker.WorkerFuture[compilation_runner.CompilationResult]]:
     # by now, all the pending work, which was signaled to cancel, must've
     # finished
     self._join_pending_jobs()
-    jobs = [(module_spec, policy_path, self._reward_stat_map[module_spec.name])
+    jobs = [(module_spec, policy, self._reward_stat_map[module_spec.name])
             for module_spec in sampled_modules]
 
     def work_factory(job):
@@ -97,7 +98,7 @@ class LocalDataCollector(data_collector.DataCollector):
     return buffered_scheduler.schedule(work, self._worker_pool, buffer=10)
 
   def collect_data(
-      self, policy_path: str
+      self, policy: compilation_runner.Policy
   ) -> Tuple[Iterator[trajectory.Trajectory], Dict[str, Dict[str, float]]]:
     """Collect data for a given policy.
 
@@ -112,7 +113,7 @@ class LocalDataCollector(data_collector.DataCollector):
       information is viewable in TensorBoard.
     """
     sampled_modules = self._corpus.sample(k=self._num_modules, sort=False)
-    self._current_futures = self._schedule_jobs(policy_path, sampled_modules)
+    self._current_futures = self._schedule_jobs(policy, sampled_modules)
 
     def wait_for_termination():
       early_exit = self._exit_checker_ctor(num_modules=self._num_modules)

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -28,14 +28,14 @@ from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import corpus
 from compiler_opt.rl import data_collector
 from compiler_opt.rl import local_data_collector
+from compiler_opt.rl import policy_saver
 
 # This is https://github.com/google/pytype/issues/764
 from google.protobuf import text_format  # pytype: disable=pyi-error
 
 _policy_str = 'policy'.encode(encoding='utf-8')
 
-_mock_policy = compilation_runner.Policy(
-    output_spec=bytes(), policy=_policy_str)
+_mock_policy = policy_saver.Policy(output_spec=bytes(), policy=_policy_str)
 
 
 def _get_sequence_example(feature_value):

--- a/compiler_opt/rl/policy_saver_test.py
+++ b/compiler_opt/rl/policy_saver_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for compiler_opt.rl.policy_saver."""
 
+import filecmp
 import json
 import os
 
@@ -142,6 +143,27 @@ class PolicySaverTest(tf.test.TestCase):
     self.assertTrue(
         tf.io.gfile.exists(
             os.path.join(tflite_dir, policy_saver.OUTPUT_SIGNATURE)))
+
+  def test_policy_serialization(self):
+    sm_dir = os.path.join(self.get_temp_dir(), 'model')
+    orig_dir = os.path.join(self.get_temp_dir(), 'orig_model')
+    dest_dir = os.path.join(self.get_temp_dir(), 'dest_model')
+    _gen_test_model(sm_dir)
+    policy_saver.convert_mlgo_model(sm_dir, orig_dir)
+
+    serialized_policy = policy_saver.Policy.from_filesystem(orig_dir)
+    serialized_policy.to_filesystem(dest_dir)
+
+    self.assertTrue(
+        filecmp.cmp(
+            os.path.join(orig_dir, policy_saver.TFLITE_MODEL_NAME),
+            os.path.join(dest_dir, policy_saver.TFLITE_MODEL_NAME),
+            shallow=False))
+    self.assertTrue(
+        filecmp.cmp(
+            os.path.join(orig_dir, policy_saver.OUTPUT_SIGNATURE),
+            os.path.join(dest_dir, policy_saver.OUTPUT_SIGNATURE),
+            shallow=False))
 
 
 if __name__ == '__main__':

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -157,7 +157,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
       saver.save(policy_path)
 
       dataset_iter, monitor_dict = data_collector.collect_data(
-          policy=compilation_runner.Policy.from_filesystem(
+          policy=policy_saver.Policy.from_filesystem(
               os.path.join(policy_path, deploy_policy_name)))
       llvm_trainer.train(dataset_iter, monitor_dict, num_iterations)
 

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -157,7 +157,8 @@ def train_eval(agent_name=constant.AgentName.PPO,
       saver.save(policy_path)
 
       dataset_iter, monitor_dict = data_collector.collect_data(
-          policy_path=os.path.join(policy_path, deploy_policy_name))
+          policy=compilation_runner.Policy.from_filesystem(
+              os.path.join(policy_path, deploy_policy_name)))
       llvm_trainer.train(dataset_iter, monitor_dict, num_iterations)
 
       data_collector.on_dataset_consumed(dataset_iter)

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -31,6 +31,7 @@ import tensorflow as tf
 
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import corpus
+from compiler_opt.rl import policy_saver
 from compiler_opt.rl import registry
 
 # see https://bugs.python.org/issue33315 - we do need these types, but must
@@ -96,7 +97,7 @@ def worker(policy_path: Optional[str],
   try:
     runner = get_runner()
     m = re.compile(key_filter) if key_filter else None
-    policy = compilation_runner.Policy.from_filesystem(
+    policy = policy_saver.Policy.from_filesystem(
         policy_path) if policy_path else None
     while True:
       try:

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -34,7 +34,7 @@ flags.FLAGS['num_workers'].allow_override = True
 class MockCompilationRunner(compilation_runner.CompilationRunner):
   """A compilation runner just for test."""
 
-  def collect_data(self, module_spec, tf_policy_path, reward_stat):
+  def collect_data(self, module_spec, policy, reward_stat):
     sequence_example_text = """
       feature_lists {
         feature_list {


### PR DESCRIPTION
This sets up the trainer to work with potentially remote workers by passing a serialized object to them. Each worker, then, serializes the policy locally, after which data collection continues as usual.

The main inefficiency is that we save the policy per request handler, and even if the training is local. Policies are small objects, however (at least currently), so this shouldn't be cause of concern. Upon measuring this for 100 and then 500 modules, with 128 workers:

- 100 modules: ~7% regression in the compile time component of training
- 500 modules: ~9% improvement

At this point, I'd take neither regression nor improvement as meaningful, and since, additionally, compilation time is about 1/10 of overall time, the complexity tradeoff of a design optimizing for the local case is probably not worth it.