### PR TITLE
Make the corpus remote wrt workers

### DIFF
--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -94,7 +94,8 @@ def _mock_compile_fn(file_paths, tf_policy_path, reward_only):  # pylint: disabl
 
 _mock_policy = policy_saver.Policy(bytes(), bytes())
 
-_mock_loaded_module_spec = corpus.LoadedModuleSpec(name='dummy', module=bytes())
+_mock_loaded_module_spec = corpus.LoadedModuleSpec(
+    name='dummy', loaded_ir=bytes())
 
 
 class CompilationRunnerTest(tf.test.TestCase):

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -94,6 +94,8 @@ def _mock_compile_fn(file_paths, tf_policy_path, reward_only):  # pylint: disabl
 
 _mock_policy = policy_saver.Policy(bytes(), bytes())
 
+_mock_loaded_module_spec = corpus.LoadedModuleSpec(name='dummy', module=bytes())
+
 
 class CompilationRunnerTest(tf.test.TestCase):
 
@@ -111,7 +113,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
     data = runner.collect_data(
-        module_spec=corpus.ModuleSpec(name='dummy'), policy=_mock_policy)
+        loaded_module_spec=_mock_loaded_module_spec, policy=_mock_policy)
     self.assertEqual(2, mock_compile_fn.call_count)
 
     expected_example = _get_sequence_example_with_reward(
@@ -139,7 +141,7 @@ class CompilationRunnerTest(tf.test.TestCase):
     runner = compilation_runner.CompilationRunner(
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
-    data = runner.collect_data(module_spec=corpus.ModuleSpec(name='dummy'))
+    data = runner.collect_data(loaded_module_spec=_mock_loaded_module_spec)
     # One call when we ask for the default policy, because it can provide both
     # trace and default size.
     self.assertEqual(1, mock_compile_fn.call_count)
@@ -168,7 +170,7 @@ class CompilationRunnerTest(tf.test.TestCase):
         moving_average_decay_rate=_MOVING_AVERAGE_DECAY_RATE)
 
     data = runner.collect_data(
-        module_spec=corpus.ModuleSpec(name='dummy'),
+        loaded_module_spec=_mock_loaded_module_spec,
         policy=_mock_policy,
         reward_stat={
             'default':
@@ -205,7 +207,7 @@ class CompilationRunnerTest(tf.test.TestCase):
 
     with self.assertRaisesRegex(subprocess.CalledProcessError, 'error'):
       _ = runner.collect_data(
-          module_spec=corpus.ModuleSpec(name='dummy'),
+          loaded_module_spec=_mock_loaded_module_spec,
           policy=_mock_policy,
           reward_stat=None)
     self.assertEqual(1, mock_compile_fn.call_count)

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -13,16 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ModuleSpec definition and utility command line parsing functions."""
+import abc
 import math
 import random
 import re
 
 from absl import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import json
 import os
+import tensorflow as tf
 
 from compiler_opt.rl import constant
 
@@ -32,11 +34,128 @@ class ModuleSpec:
   """Dataclass describing an input module and its compilation command options.
   """
   name: str
-  exec_cmd: Tuple[str, ...] = ()
-  size: int = 0
+  exec_cmd: Tuple[str, ...]
+  size: int
 
 
-class SamplerBucketRoundRobin:
+def _localize_cmdline(
+    orig_options: Tuple[str, ...],
+    context: Any = None,
+    additional_flags: Tuple[str, ...] = (),
+    delete_flags: Tuple[str, ...] = (),
+    replace_flags: Optional[Dict[str, str]] = None) -> List[str]:
+  option_iterator = iter(orig_options)
+  matched_replace_flags = set()
+  replace_flags = replace_flags if replace_flags is not None else {}
+
+  option = next(option_iterator, None)
+  cmdline = []
+  while option is not None:
+    if any(option.startswith(flag) for flag in delete_flags):
+      if '=' not in option:
+        next(option_iterator, None)
+    else:
+      matching_replace = [
+          flag for flag in replace_flags if option.startswith(flag)
+      ]
+      if not matching_replace:
+        cmdline.append(option)
+      else:
+        assert len(matching_replace) == 1
+        flag = matching_replace[0]
+        if flag in matched_replace_flags:
+          raise ValueError(f'{flag} was matched twice')
+        matched_replace_flags.add(flag)
+
+        if '=' not in option:
+          next(option_iterator, None)
+          cmdline.extend([option, replace_flags[flag].format(context=context)])
+        else:
+          cmdline.append(flag + '=' +
+                         replace_flags[flag].format(context=context))
+
+    option = next(option_iterator, None)
+  if len(matched_replace_flags) != len(replace_flags):
+    raise ValueError('flags that were expected to be replaced were not found')
+  cmdline.extend([f.format(context=context) for f in additional_flags])
+  return cmdline
+
+
+@dataclass(frozen=True)
+class LoadedModuleSpec:
+  """Encapsulates the loaded data of a module and the rules to persist it.
+
+  A LoadedModuleSpec can be passed to a remote location. There, given a local
+  directory, to_module_spec can be called, resulting in the data being saved
+  under that directory, the final compiler command line fully computed, and a
+  ready-to-use ModuleSpec returned.
+  """
+  name: str
+  module: bytes
+  thinlto_index: Optional[bytes] = None
+  orig_options: Tuple[str, ...] = ()
+  additional_flags: Tuple[str, ...] = ()
+  delete_flags: Tuple[str, ...] = ()
+  replace_flags: Optional[Dict[str, str]] = None
+
+  def _create_files_and_get_context(self, local_dir: str):
+    root_dir = os.path.join(local_dir, self.name)
+    os.makedirs(root_dir, exist_ok=True)
+    module_path = os.path.join(root_dir, 'input.bc')
+    thinlto_index_path = None
+    with tf.io.gfile.GFile(module_path, 'wb') as f:
+      f.write(self.module)
+    if self.thinlto_index is not None:
+      thinlto_index_path = os.path.join(root_dir, 'index.thinlto.bc')
+      with tf.io.gfile.GFile(thinlto_index_path, 'wb') as f:
+        f.write(self.thinlto_index)
+    context = Corpus.ReplaceContext(
+        module_full_path=module_path, thinlto_full_path=thinlto_index_path)
+    return context
+
+  def to_module_spec(self, local_dir: str) -> ModuleSpec:
+    context = self._create_files_and_get_context(local_dir)
+    cmdline = _localize_cmdline(
+        context=context,
+        orig_options=self.orig_options,
+        additional_flags=self.additional_flags,
+        delete_flags=self.delete_flags,
+        replace_flags=self.replace_flags)
+    return ModuleSpec(
+        name=self.name, exec_cmd=tuple(cmdline), size=len(self.module))
+
+
+@dataclass(frozen=True)
+class CorpusElement:
+  """Metadata of a compilation unit.
+  This contains the necessary information to enable corpus operations like
+  sampling or filtering, as well as to enable the corpus create
+  a LoadedModuleSpec from a CorpusElement.
+  """
+  name: str
+  size: int
+  command_line: Tuple[str, ...] = ()
+  has_thinlto: bool = False
+
+
+class Sampler(metaclass=abc.ABCMeta):
+  """Corpus sampler abstraction."""
+
+  @abc.abstractmethod
+  def __call__(self,
+               module_specs: Tuple[CorpusElement],
+               k: int,
+               n: int = 20) -> List[CorpusElement]:
+    """
+    Args:
+      module_specs: list of module_specs to sample from
+      k: number of modules to sample
+      n: number of buckets to use
+    """
+    raise NotImplementedError()
+
+
+class SamplerBucketRoundRobin(Sampler):
   """Calls return a list of module_specs sampled randomly from n buckets, in
   round-robin order. The buckets are sequential sections of module_specs of
   roughly equal lengths."""
@@ -45,9 +164,9 @@ class SamplerBucketRoundRobin:
     self._ranges = {}
 
   def __call__(self,
-               module_specs: Tuple[ModuleSpec],
+               module_specs: Tuple[CorpusElement],
                k: int,
-               n: int = 20) -> List[ModuleSpec]:
+               n: int = 20) -> List[CorpusElement]:
     """
     Args:
       module_specs: list of module_specs to sample from
@@ -85,14 +204,23 @@ class Corpus:
   @dataclass(frozen=True)
   class ReplaceContext:
     """Context for 'replace' rules."""
-    full_path_prefix: str
+    module_full_path: str
+    thinlto_full_path: Optional[str] = None
 
   def __init__(self,
+               *,
                data_path: str,
+               module_filter: Optional[re.Pattern] = None,
                additional_flags: Tuple[str, ...] = (),
                delete_flags: Tuple[str, ...] = (),
-               replace_flags: Optional[Dict[str, str]] = None):
+               replace_flags: Optional[Dict[str, str]] = None,
+               sampler: Sampler = SamplerBucketRoundRobin()):
     """
+    Prepares the corpus by pre-loading all the CorpusElements and preparing for
+    sampling. Command line origin (.cmd file or override) is decided, and final
+    command line transformation rules are set (i.e. thinlto flags handled, also
+    output) and validated.
+
     Args:
       data_path: corpus directory.
       additional_flags: list of flags to append to the command line
@@ -104,194 +232,160 @@ class Corpus:
         We verify that flags in replace_flags are present, and do not appear
         in the additional_flags nor delete_flags.
         Thinlto index is handled this way, too.
+      module_filter: a regular expression used to filter 'in' modules with names
+        matching it. None to include everything.
     """
-    self._module_specs = tuple(
-        sorted(
-            _build_modulespecs_from_datapath(
-                data_path=data_path,
-                additional_flags=additional_flags,
-                delete_flags=delete_flags,
-                replace_flags=replace_flags),
-            key=lambda m: m.size,
-            reverse=True))
-    self._root_dir = data_path
+    self._base_dir = data_path
+    self._sampler = sampler
+    # TODO: (b/233935329) Per-corpus *fdo profile paths can be read into
+    # {additional|delete}_flags here
+    with tf.io.gfile.GFile(
+        os.path.join(data_path, 'corpus_description.json'), 'r') as f:
+      corpus_description: Dict[str, Any] = json.load(f)
 
-  @classmethod
-  def from_module_specs(cls, module_specs: Iterable[ModuleSpec]):
-    """Construct a Corpus from module specs. Mostly for testing purposes."""
-    cps = cls.__new__(cls)  # Avoid calling __init__
-    super(cls, cps).__init__()
-    cps._module_specs = tuple(
-        sorted(module_specs, key=lambda m: m.size, reverse=True))
-    cps.root_dir = None
-    return cps
+    module_paths = corpus_description['modules']
+    if len(module_paths) == 0:
+      raise ValueError(
+          f'{data_path}\'s corpus_description contains no modules.')
 
-  def sample(self,
-             k: int,
-             sort: bool = False,
-             sampler=SamplerBucketRoundRobin()) -> List[ModuleSpec]:
-    """Samples `k` module_specs, optionally sorting by size descending."""
+    has_thinlto: bool = corpus_description['has_thinlto']
+
+    cmd_override = ()
+    cmd_override_was_specified = False
+    if 'global_command_override' in corpus_description:
+      cmd_override_was_specified = True
+      if corpus_description[
+          'global_command_override'] == constant.UNSPECIFIED_OVERRIDE:
+        raise ValueError(
+            'global_command_override in corpus_description.json not filled.')
+      cmd_override = tuple(corpus_description['global_command_override'])
+      if len(additional_flags) > 0:
+        logging.warning(
+            'Additional flags are specified together with override.')
+      if len(delete_flags) > 0:
+        logging.warning('Delete flags are specified together with override.')
+
+    def get_cmdline(name: str):
+      if cmd_override_was_specified:
+        return cmd_override
+      else:
+        with tf.io.gfile.GFile(os.path.join(data_path, name + '.cmd')) as f:
+          ret = tuple(f.read().split('\0'))
+          # The options read from a .cmd file must be run with -cc1
+          if ret[0] != '-cc1':
+            raise ValueError('-cc1 flag not present in .cmd file.')
+          return ret
+
+    contents = [
+        CorpusElement(
+            name=name,
+            size=os.path.getsize(os.path.join(data_path, name + '.bc')),
+            command_line=get_cmdline(name),
+            has_thinlto=has_thinlto)
+        for name in module_paths
+        if not module_filter or module_filter.match(name)
+    ]
+    self._contents = tuple(sorted(contents, key=lambda m: m.size, reverse=True))
+
+    replace_flags = replace_flags.copy() if replace_flags else {}
+    fthinlto_index_flag = '-fthinlto-index'
+
+    if has_thinlto:
+      additional_flags = ('-mllvm', '-thinlto-assume-merged') + additional_flags
+      if cmd_override_was_specified:
+        additional_flags = (f'{fthinlto_index_flag}=' +
+                            '{context.thinlto_full_path}',) + additional_flags
+      else:
+        if fthinlto_index_flag in replace_flags:
+          raise ValueError(
+              '-fthinlto-index must be handled by the infrastructure')
+        replace_flags[fthinlto_index_flag] = '{context.thinlto_full_path}'
+
+    additional_flags = ('-x', 'ir',
+                        '{context.module_full_path}') + additional_flags
+
+    # don't use add/remove for replace
+    add_keys = set(k.split('=', maxsplit=1)[0] for k in additional_flags)
+    if add_keys.intersection(
+        set(replace_flags)) or set(delete_flags).intersection(
+            set(replace_flags)) or add_keys.intersection(set(delete_flags)):
+      raise ValueError('do not use add/delete flags to replace')
+
+    self._additional_flags = additional_flags
+    self._delete_flags = delete_flags
+    self._replace_flags = replace_flags
+
+  def sample(self, k: int, sort: bool = False) -> List[CorpusElement]:
+    """Samples `k` module_specs, optionally sorting by size descending.
+
+    Use load_corpus_element to get LoadedModuleSpecs - this allows the user
+    decide how the loading should happen (e.g. may want to use a threadpool)
+    """
     # Note: sampler is intentionally defaulted to a mutable object, as the
     # only mutable attribute of SamplerBucketRoundRobin is its range cache.
-    k = min(len(self._module_specs), k)
+    k = min(len(self._contents), k)
     if k < 1:
       raise ValueError('Attempting to sample <1 module specs from corpus.')
-    sampled_specs = sampler(self._module_specs, k=k)
+    sampled_specs = self._sampler(self._contents, k=k)
     if sort:
       sampled_specs.sort(key=lambda m: m.size, reverse=True)
     return sampled_specs
 
-  def filter(self, p: re.Pattern):
-    """Filters module specs, keeping those which match the provided pattern."""
-    return Corpus.from_module_specs(
-        (ms for ms in self._module_specs if p.match(ms.name)))
+  def load_corpus_element(self,
+                          corpus_element: CorpusElement) -> LoadedModuleSpec:
+    with tf.io.gfile.GFile(
+        os.path.join(self._base_dir, corpus_element.name + '.bc'), 'rb') as f:
+      module_bytes = f.read()
+    thinlto_bytes = None
+    if corpus_element.has_thinlto:
+      with tf.io.gfile.GFile(
+          os.path.join(self._base_dir, corpus_element.name + '.thinlto.bc'),
+          'rb') as f:
+        thinlto_bytes = f.read()
+    return LoadedModuleSpec(
+        name=corpus_element.name,
+        module=module_bytes,
+        thinlto_index=thinlto_bytes,
+        orig_options=corpus_element.command_line,
+        additional_flags=self._additional_flags,
+        delete_flags=self._delete_flags,
+        replace_flags=self._replace_flags)
 
   @property
-  def module_specs(self):
-    return self._module_specs
+  def contents(self):
+    return self._contents
 
   def __len__(self):
-    return len(self._module_specs)
+    return len(self._contents)
 
 
-def _build_modulespecs_from_datapath(
-    data_path: str,
-    additional_flags: Tuple[str, ...] = (),
-    delete_flags: Tuple[str, ...] = (),
-    replace_flags: Optional[Dict[str, str]] = None) -> List[ModuleSpec]:
-  # TODO: (b/233935329) Per-corpus *fdo profile paths can be read into
-  # {additional|delete}_flags here
-  with open(
-      os.path.join(data_path, 'corpus_description.json'), 'r',
-      encoding='utf-8') as f:
-    corpus_description: Dict[str, Any] = json.load(f)
+def create_corpus_for_testing(location: str,
+                              elements: List[CorpusElement],
+                              cmdline: Tuple[str, ...] = ('-cc1',),
+                              cmdline_is_override=False,
+                              is_thinlto=False,
+                              **kwargs) -> Corpus:
+  os.makedirs(location, exist_ok=True)
+  for element in elements:
+    with tf.io.gfile.GFile(os.path.join(location, element.name + '.bc'),
+                           'wb') as f:
+      f.write(bytes([1] * element.size))
+    if not cmdline_is_override:
+      with tf.io.gfile.GFile(
+          os.path.join(location, element.name + '.cmd'), 'w') as f:
+        f.write('\0'.join(cmdline))
+    if is_thinlto:
+      with tf.io.gfile.GFile(
+          os.path.join(location, element.name + '.thinlto.bc'), 'w') as f:
+        f.write('')
 
-  module_paths = corpus_description['modules']
-  if len(module_paths) == 0:
-    raise ValueError(f'{data_path}\'s corpus_description contains no modules.')
-
-  has_thinlto: bool = corpus_description['has_thinlto']
-
-  cmd_override = ()
-  if 'global_command_override' in corpus_description:
-    if corpus_description[
-        'global_command_override'] == constant.UNSPECIFIED_OVERRIDE:
-      raise ValueError(
-          'global_command_override in corpus_description.json not filled.')
-    cmd_override = tuple(corpus_description['global_command_override'])
-    if len(additional_flags) > 0:
-      logging.warning('Additional flags are specified together with override.')
-    if len(delete_flags) > 0:
-      logging.warning('Delete flags are specified together with override.')
-    if replace_flags:
-      logging.warning('Replace flags are specified together with override.')
-
-  module_specs: List[ModuleSpec] = []
-
-  # This takes ~7s for 30k modules
-  for rel_module_path in module_paths:
-    full_module_path = os.path.join(data_path, rel_module_path)
-    exec_cmd = _load_and_parse_command(
-        module_path=full_module_path,
-        has_thinlto=has_thinlto,
-        additional_flags=additional_flags,
-        delete_flags=delete_flags,
-        replace_flags=replace_flags,
-        cmd_override=cmd_override)
-    size = os.path.getsize(full_module_path + '.bc')
-    module_specs.append(
-        ModuleSpec(name=rel_module_path, exec_cmd=tuple(exec_cmd), size=size))
-
-  return module_specs
-
-
-def _load_and_parse_command(
-    module_path: str,
-    has_thinlto: bool,
-    additional_flags: Tuple[str, ...] = (),
-    delete_flags: Tuple[str, ...] = (),
-    replace_flags: Optional[Dict[str, str]] = None,
-    cmd_override: Tuple[str, ...] = (),
-) -> List[str]:
-  """Cleans up base command line.
-
-  Remove certain unnecessary flags, and add the .bc file to compile and, if
-  given, the thinlto index.
-
-  Args:
-    module_path: Absolute path to the module without extension (from corpus).
-    has_thinlto: Whether to add thinlto flags.
-    additional_flags: Tuple of clang flags to add.
-    delete_flags: Tuple of clang flags to remove.
-    cmd_override: Tuple of strings to use as the base command line.
-
-  Returns:
-    The argument list to pass to the compiler process.
-  """
-  cmdline = []
-
-  if cmd_override:
-    option_iterator = iter(cmd_override)
-  else:
-    with open(module_path + '.cmd', encoding='utf-8') as f:
-      option_iterator = iter(f.read().split('\0'))
-
-  context = Corpus.ReplaceContext(full_path_prefix=module_path)
-  replace_flags = replace_flags.copy() if replace_flags else {}
-  if has_thinlto:
-    additional_flags = ('-mllvm', '-thinlto-assume-merged') + additional_flags
-    if cmd_override:
-      additional_flags = (
-          f'-fthinlto-index={context.full_path_prefix}.thinlto.bc',
-      ) + additional_flags
-    else:
-      fthinlto_index = '-fthinlto-index'
-      if fthinlto_index in replace_flags:
-        raise ValueError(
-            '-fthinlto-index must be handled by the infrastructure')
-      replace_flags[fthinlto_index] = '{context.full_path_prefix}.thinlto.bc'
-
-  additional_flags = ('-x', 'ir', module_path + '.bc') + additional_flags
-
-  matched_replace_flags = set()
-  # don't user add/remove for replace
-  if set(additional_flags).intersection(
-      set(replace_flags)) or set(delete_flags).intersection(set(replace_flags)):
-    raise ValueError('do not use add/delete flags to replace')
-
-  option = next(option_iterator, None)
-
-  while option is not None:
-    if any(option.startswith(flag) for flag in delete_flags):
-      if '=' not in option:
-        next(option_iterator, None)
-    else:
-      matching_replace = [
-          flag for flag in replace_flags if option.startswith(flag)
-      ]
-      if not matching_replace:
-        cmdline.append(option)
-      else:
-        assert len(matching_replace) == 1
-        flag = matching_replace[0]
-        if flag in matched_replace_flags:
-          raise ValueError(f'{flag} was matched twice')
-        matched_replace_flags.add(flag)
-
-        if '=' not in option:
-          next(option_iterator, None)
-          cmdline.extend([option, replace_flags[flag].format(context=context)])
-        else:
-          cmdline.append(flag + '=' +
-                         replace_flags[flag].format(context=context))
-
-    option = next(option_iterator, None)
-  if len(matched_replace_flags) != len(replace_flags):
-    raise ValueError('flags that were expected to be replaced were not found')
-  cmdline.extend(additional_flags)
-
-  # The options read from a .cmd file must be run with -cc1
-  if not cmd_override and cmdline[0] != '-cc1':
-    raise ValueError('-cc1 flag not present in .cmd file.')
-
-  return cmdline
+  corpus_description = {
+      'modules': [e.name for e in elements],
+      'has_thinlto': is_thinlto,
+  }
+  if cmdline_is_override:
+    corpus_description['global_command_override'] = cmdline
+  with tf.io.gfile.GFile(
+      os.path.join(location, 'corpus_description.json'), 'w') as f:
+    f.write(json.dumps(corpus_description))
+  return Corpus(data_path=location, **kwargs)

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -98,7 +98,7 @@ class ModuleSpecTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[corpus.ModuleSpec(name='smth', size=1)])
-    lms = cps.load_module_spec(cps.contents[0])
+    lms = cps.load_module_spec(cps.module_specs[0])
     corpdir2 = self.create_tempdir()
     fqcmd = lms.build_command_line(corpdir2)
     bc_loc = os.path.join(corpdir2, 'smth', 'input.bc')
@@ -116,7 +116,7 @@ class CorpusTest(tf.test.TestCase):
         additional_flags=('-add',))
     self.assertEqual((corpus.ModuleSpec(
         name='1', size=1, command_line=('-cc1',), has_thinlto=False),),
-                     cps.contents)
+                     cps.module_specs)
     self.assertEqual(len(cps), 1)
     self.assertEqual(cps._additional_flags,
                      ('-x', 'ir', '{context.module_full_path}', '-add'))
@@ -219,7 +219,7 @@ class CorpusTest(tf.test.TestCase):
                      ('-x', 'ir', '{context.module_full_path}',
                       '-fthinlto-index={context.thinlto_full_path}', '-mllvm',
                       '-thinlto-assume-merged'))
-    self.assertEqual(cps.contents[0].command_line, ('-something',))
+    self.assertEqual(cps.module_specs[0].command_line, ('-something',))
 
   def test_sample(self):
     cps = corpus.create_corpus_for_testing(

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Tests for the ModuleSpec dataclass and its utility functions."""
 # pylint: disable=protected-access
-import json
+from dataclasses import dataclass
 import os
 import re
 
@@ -25,292 +25,211 @@ from compiler_opt.rl import corpus
 
 class CommandParsingTest(tf.test.TestCase):
 
-  def test_thinlto_file(self):
-    data = ['-cc1', '-foo', '-bar=baz']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path, has_thinlto=False),
-        ['-cc1', '-foo', '-bar=baz', '-x', 'ir', module_path + '.bc'])
-    data = ['-cc1', '-foo', '-bar=baz', '-fthinlto-index=some/path/here']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path, has_thinlto=True), [
-                '-cc1', '-foo', '-bar=baz',
-                '-fthinlto-index=' + module_path + '.thinlto.bc', '-x', 'ir',
-                module_path + '.bc', '-mllvm', '-thinlto-assume-merged'
-            ])
-
   def test_deletion(self):
-    delete_compilation_flags = ('-split-dwarf-file', '-split-dwarf-output',
-                                '-fthinlto-index', '-fprofile-sample-use',
-                                '-fprofile-remapping-file')
-    data = [
-        '-cc1', '-fthinlto-index=bad', '-split-dwarf-file', '/tmp/foo.dwo',
-        '-split-dwarf-output', 'somepath/some.dwo'
-    ]
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
     self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            delete_flags=delete_compilation_flags),
-        ['-cc1', '-x', 'ir', module_path + '.bc'])
+        ['-cc1'],
+        corpus._localize_cmdline(
+            orig_options=('-cc1', '-fthinlto-index=bad', '-split-dwarf-file',
+                          '/tmp/foo.dwo', '-split-dwarf-output',
+                          'somepath/some.dwo'),
+            delete_flags=('-split-dwarf-file', '-split-dwarf-output',
+                          '-fthinlto-index', '-fprofile-sample-use',
+                          '-fprofile-remapping-file')))
+
+    # OK to not match deletion flags
+    self.assertEqual(['-cc1'],
+                     corpus._localize_cmdline(
+                         orig_options=('-cc1',),
+                         delete_flags=('-split-dwarf-file',
+                                       '-split-dwarf-output', '-fthinlto-index',
+                                       '-fprofile-sample-use',
+                                       '-fprofile-remapping-file')))
 
   def test_addition(self):
-    additional_flags = ('-fix-all-bugs',)
-    data = ['-cc1']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
     self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            additional_flags=additional_flags),
-        ['-cc1', '-x', 'ir', module_path + '.bc', '-fix-all-bugs'])
+        ['-cc1', '-fix-all-bugs', '-something=/hello/there.txt'],
+        corpus._localize_cmdline(
+            context=corpus.Corpus.ReplaceContext(
+                module_full_path='/hello/there.txt'),
+            orig_options=('-cc1',),
+            additional_flags=('-fix-all-bugs',
+                              '-something={context.module_full_path}')))
 
   def test_replacement(self):
-    replace_flags = {'-replace-me': '{context.full_path_prefix}.replaced'}
-    data = ['-cc1']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
+
+    @dataclass(frozen=True)
+    class ToyContext:
+      some_field: str
+
     # if we expect to be able to replace a flag, and it's not in the original
     # cmdline, raise.
-    self.assertRaises(
+    with self.assertRaises(
         ValueError,
-        corpus._load_and_parse_command,
-        module_path=module_path,
-        has_thinlto=False,
-        replace_flags=replace_flags)
-    data = ['-cc1', '-replace-me=some_value']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    # the flag can be replaced in non-thinlto cases; and in the case of thinlto
-    # it does not interfere with the thinlto one
+        msg='flags that were expected to be replaced were not found'):
+      corpus._localize_cmdline(
+          orig_options=('-cc1',),
+          replace_flags={'-replace-me': '{context.some_field}.replaced'})
+
+    # it also raises if the context is invalid
+    self.assertRaises(
+        KeyError,
+        corpus._localize_cmdline,
+        orig_options=('-cc1', '-replace-me=blah'),
+        replace_flags={'-replace-me': '{something_that_doesnt_exist}'})
+
     self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            replace_flags=replace_flags), [
-                '-cc1', '-replace-me=' + module_path + '.replaced', '-x', 'ir',
-                module_path + '.bc'
-            ])
+        ['-cc1', '-replace-me=some_other_value.replaced'],
+        corpus._localize_cmdline(
+            context=ToyContext(some_field='some_other_value'),
+            orig_options=('-cc1', '-replace-me=some_value'),
+            replace_flags={'-replace-me': '{context.some_field}.replaced'}))
     # variant without '='
-    data = ['-cc1', '-replace-me', 'some_value']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
     self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            replace_flags=replace_flags), [
-                '-cc1', '-replace-me', module_path + '.replaced', '-x', 'ir',
-                module_path + '.bc'
-            ])
-    data = ['-cc1', '-replace-me', 'some_value', '-fthinlto-index=blah']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=True,
-            replace_flags=replace_flags), [
-                '-cc1', '-replace-me', module_path + '.replaced',
-                '-fthinlto-index=' + module_path + '.thinlto.bc', '-x', 'ir',
-                module_path + '.bc', '-mllvm', '-thinlto-assume-merged'
-            ])
-
-  def test_modification(self):
-    delete_compilation_flags = ('-split-dwarf-file', '-split-dwarf-output',
-                                '-fthinlto-index', '-fprofile-sample-use',
-                                '-fprofile-remapping-file')
-    additional_flags = ('-fix-all-bugs',)
-    data = [
-        '-cc1', '-fthinlto-index=bad', '-split-dwarf-file', '/tmp/foo.dwo',
-        '-split-dwarf-output', 'somepath/some.dwo'
-    ]
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            delete_flags=delete_compilation_flags,
-            additional_flags=additional_flags),
-        ['-cc1', '-x', 'ir', module_path + '.bc', '-fix-all-bugs'])
-
-  def test_override(self):
-    cmd_override = ('-fix-all-bugs',)
-    data = ['-cc1', '-fthinlto-index=bad']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=module_path,
-            has_thinlto=False,
-            cmd_override=cmd_override,
-            additional_flags=('-add-bugs',),
-            delete_flags=('-fthinlto-index',)),
-        ['-fix-all-bugs', '-x', 'ir', module_path + '.bc', '-add-bugs'])
-    self.assertEqual(
-        corpus._load_and_parse_command(
-            module_path=os.path.join('this!path#cant$exist/'
-                                     'hi'),
-            has_thinlto=False,
-            cmd_override=cmd_override),
-        ['-fix-all-bugs', '-x', 'ir', 'this!path#cant$exist/hi.bc'])
-
-  def test_cc1_exists(self):
-    data = ['-fix-all-bugs', '-xyz']
-    argfile = self.create_tempfile(content='\0'.join(data), file_path='hi.cmd')
-    module_path = argfile.full_path[:-4]
-    self.assertRaises(
-        ValueError,
-        corpus._load_and_parse_command,
-        module_path=module_path,
-        has_thinlto=False)
+        ['-cc1', '-replace-me', 'some_other_value.replaced'],
+        corpus._localize_cmdline(
+            context=ToyContext(some_field='some_other_value'),
+            orig_options=('-cc1', '-replace-me', 'some_value'),
+            replace_flags={'-replace-me': '{context.some_field}.replaced'}))
 
 
 class ModuleSpecTest(tf.test.TestCase):
 
-  def test_cmd(self):
-    ms = corpus.ModuleSpec(exec_cmd=('-cc1', '-fix-all-bugs'), name='dummy')
-    self.assertEqual(ms.name, 'dummy')
-    self.assertEqual(ms.exec_cmd, ('-cc1', '-fix-all-bugs'))
-
-  def test_get_without_thinlto(self):
-    corpus_description = {'modules': ['1', '2'], 'has_thinlto': False}
-    tempdir = self.create_tempdir()
-    tempdir.create_file(
-        'corpus_description.json', content=json.dumps(corpus_description))
-    tempdir.create_file('1.bc')
-    tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
-    tempdir.create_file('2.bc')
-    tempdir.create_file('2.cmd', content='\0'.join(['-cc1', '-O3']))
-
-    ms_list = corpus._build_modulespecs_from_datapath(
-        tempdir.full_path, additional_flags=('-add',))
-    self.assertEqual(len(ms_list), 2)
-    ms1 = ms_list[0]
-    ms2 = ms_list[1]
-    self.assertEqual(ms1.name, '1')
-    self.assertEqual(ms1.exec_cmd,
-                     ('-cc1', '-x', 'ir', tempdir.full_path + '/1.bc', '-add'))
-
-    self.assertEqual(ms2.name, '2')
-    self.assertEqual(
-        ms2.exec_cmd,
-        ('-cc1', '-O3', '-x', 'ir', tempdir.full_path + '/2.bc', '-add'))
-
-  def test_get_with_thinlto(self):
-    corpus_description = {'modules': ['1', '2'], 'has_thinlto': True}
-    tempdir = self.create_tempdir()
-    tempdir.create_file(
-        'corpus_description.json', content=json.dumps(corpus_description))
-    tempdir.create_file('1.bc')
-    tempdir.create_file('1.thinlto.bc')
-    tempdir.create_file(
-        '1.cmd', content='\0'.join(['-cc1', '-fthinlto-index=xyz']))
-    tempdir.create_file('2.bc')
-    tempdir.create_file('2.thinlto.bc')
-    tempdir.create_file(
-        '2.cmd', content='\0'.join(['-cc1', '-fthinlto-index=abc']))
-
-    self.assertRaises(
-        ValueError,
-        corpus._build_modulespecs_from_datapath,
-        tempdir.full_path,
-        additional_flags=('-add',),
-        delete_flags=('-fthinlto-index',))
-    ms_list = corpus._build_modulespecs_from_datapath(
-        tempdir.full_path, additional_flags=('-add',))
-    self.assertEqual(len(ms_list), 2)
-    ms1 = ms_list[0]
-    ms2 = ms_list[1]
-    self.assertEqual(ms1.name, '1')
-    self.assertEqual(ms1.exec_cmd,
-                     ('-cc1', '-fthinlto-index=' + tempdir.full_path +
-                      '/1.thinlto.bc', '-x', 'ir', tempdir.full_path + '/1.bc',
-                      '-mllvm', '-thinlto-assume-merged', '-add'))
-
-    self.assertEqual(ms2.name, '2')
-    self.assertEqual(ms2.exec_cmd,
-                     ('-cc1', '-fthinlto-index=' + tempdir.full_path +
-                      '/2.thinlto.bc', '-x', 'ir', tempdir.full_path + '/2.bc',
-                      '-mllvm', '-thinlto-assume-merged', '-add'))
-
-  def test_get_with_override(self):
-    corpus_description = {
-        'modules': ['1', '2'],
-        'has_thinlto': True,
-        'global_command_override': ['-O3', '-qrs']
-    }
-    tempdir = self.create_tempdir()
-    tempdir.create_file(
-        'corpus_description.json', content=json.dumps(corpus_description))
-    tempdir.create_file('1.bc')
-    tempdir.create_file('1.thinlto.bc')
-    tempdir.create_file(
-        '1.cmd', content='\0'.join(['-cc1', '-fthinlto-index=xyz']))
-    tempdir.create_file('2.bc')
-    tempdir.create_file('2.thinlto.bc')
-    tempdir.create_file('2.cmd', content='\0'.join(['-fthinlto-index=abc']))
-
-    ms_list = corpus._build_modulespecs_from_datapath(
-        tempdir.full_path, additional_flags=('-add',))
-    self.assertEqual(len(ms_list), 2)
-    ms1 = ms_list[0]
-    ms2 = ms_list[1]
-    self.assertEqual(ms1.name, '1')
-    self.assertEqual(ms1.exec_cmd,
-                     ('-O3', '-qrs', '-x', 'ir', tempdir.full_path + '/1.bc',
-                      '-fthinlto-index=' + tempdir.full_path + '/1.thinlto.bc',
-                      '-mllvm', '-thinlto-assume-merged', '-add'))
-
-    self.assertEqual(ms2.name, '2')
-    self.assertEqual(ms2.exec_cmd,
-                     ('-O3', '-qrs', '-x', 'ir', tempdir.full_path + '/2.bc',
-                      '-fthinlto-index=' + tempdir.full_path + '/2.thinlto.bc',
-                      '-mllvm', '-thinlto-assume-merged', '-add'))
-
-  def test_size(self):
-    corpus_description = {'modules': ['1'], 'has_thinlto': False}
-    tempdir = self.create_tempdir()
-    tempdir.create_file(
-        'corpus_description.json', content=json.dumps(corpus_description))
-    bc_file = tempdir.create_file('1.bc')
-    tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
-    self.assertEqual(
-        os.path.getsize(bc_file.full_path),
-        corpus._build_modulespecs_from_datapath(
-            tempdir.full_path, additional_flags=('-add',))[0].size)
+  def test_loadable_spec(self):
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='smth', size=1)])
+    lms = cps.load_corpus_element(cps.contents[0])
+    corpdir2 = self.create_tempdir()
+    ms = lms.to_module_spec(corpdir2)
+    bc_loc = os.path.join(corpdir2, 'smth', 'input.bc')
+    self.assertEqual(('-cc1', '-x', 'ir', f'{bc_loc}'), ms.exec_cmd)
+    with tf.io.gfile.GFile(bc_loc, 'rb') as f:
+      self.assertEqual(f.readlines(), [bytes([1])])
 
 
 class CorpusTest(tf.test.TestCase):
 
   def test_constructor(self):
-    corpus_description = {'modules': ['1'], 'has_thinlto': False}
-    tempdir = self.create_tempdir()
-    tempdir.create_file(
-        'corpus_description.json', content=json.dumps(corpus_description))
-    tempdir.create_file('1.bc')
-    tempdir.create_file('1.cmd', content='\0'.join(['-cc1']))
-
-    cps = corpus.Corpus(tempdir.full_path, additional_flags=('-add',))
-    self.assertEqual(
-        tuple(
-            corpus._build_modulespecs_from_datapath(
-                tempdir.full_path, additional_flags=('-add',))),
-        cps.module_specs)
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='1', size=1)],
+        additional_flags=('-add',))
+    self.assertEqual((corpus.CorpusElement(
+        name='1', size=1, command_line=('-cc1',), has_thinlto=False),),
+                     cps.contents)
     self.assertEqual(len(cps), 1)
+    self.assertEqual(cps._additional_flags,
+                     ('-x', 'ir', '{context.module_full_path}', '-add'))
+
+  def test_invalid_args(self):
+    with self.assertRaises(
+        ValueError, msg='-cc1 flag not present in .cmd file'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-hi',))
+
+    with self.assertRaises(
+        ValueError, msg='do not use add/delete flags to replace'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-cc1',),
+          additional_flags=('-fsomething',),
+          replace_flags={'-fsomething': 'does not matter'})
+
+    with self.assertRaises(
+        ValueError, msg='do not use add/delete flags to replace'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-cc1',),
+          additional_flags=('-fsomething=new_value',),
+          replace_flags={'-fsomething': 'does not matter'})
+
+    with self.assertRaises(
+        ValueError, msg='do not use add/delete flags to replace'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-cc1',),
+          delete_flags=('-fsomething',),
+          replace_flags={'-fsomething': 'does not matter'})
+
+    with self.assertRaises(
+        ValueError, msg='do not use add/delete flags to replace'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-cc1',),
+          additional_flags=('-fsomething',),
+          delete_flags=('-fsomething',))
+
+    with self.assertRaises(
+        ValueError, msg='do not use add/delete flags to replace'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(),
+          elements=[corpus.CorpusElement(name='smol', size=1)],
+          cmdline=('-cc1',),
+          additional_flags=('-fsomething=value',),
+          delete_flags=('-fsomething',))
+
+  def test_empty_module_list(self):
+    location = self.create_tempdir()
+    with self.assertRaises(
+        ValueError,
+        msg=f'{location}\'s corpus_description contains no modules.'):
+      corpus.create_corpus_for_testing(
+          location=self.create_tempdir(), elements=[], cmdline=('-hello',))
+
+  def test_ctor_thinlto(self):
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='smol', size=1)],
+        cmdline=('-cc1', '-fthinlto-index=foo'),
+        is_thinlto=True)
+    self.assertTrue('-fthinlto-index' in cps._replace_flags)
+    self.assertEqual(cps._replace_flags['-fthinlto-index'],
+                     '{context.thinlto_full_path}')
+    self.assertEqual(cps._additional_flags,
+                     ('-x', 'ir', '{context.module_full_path}', '-mllvm',
+                      '-thinlto-assume-merged'))
+
+  def test_cmd_override_thinlto(self):
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='smol', size=1)],
+        cmdline=(),
+        cmdline_is_override=True,
+        is_thinlto=True)
+    self.assertFalse('-fthinlto-index' in cps._replace_flags)
+    self.assertEqual(cps._additional_flags,
+                     ('-x', 'ir', '{context.module_full_path}',
+                      '-fthinlto-index={context.thinlto_full_path}', '-mllvm',
+                      '-thinlto-assume-merged'))
+
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='smol', size=1)],
+        cmdline=('-something',),
+        cmdline_is_override=True,
+        is_thinlto=True)
+    self.assertFalse('-fthinlto-index' in cps._replace_flags)
+    self.assertEqual(cps._additional_flags,
+                     ('-x', 'ir', '{context.module_full_path}',
+                      '-fthinlto-index={context.thinlto_full_path}', '-mllvm',
+                      '-thinlto-assume-merged'))
+    self.assertEqual(cps.contents[0].command_line, ('-something',))
 
   def test_sample(self):
-    cps = corpus.Corpus.from_module_specs(module_specs=[
-        corpus.ModuleSpec(name='smol', size=1),
-        corpus.ModuleSpec(name='middle', size=200),
-        corpus.ModuleSpec(name='largest', size=500),
-        corpus.ModuleSpec(name='small', size=100)
-    ])
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[
+            corpus.CorpusElement(name='smol', size=1),
+            corpus.CorpusElement(name='middle', size=200),
+            corpus.CorpusElement(name='largest', size=500),
+            corpus.CorpusElement(name='small', size=100)
+        ])
     sample = cps.sample(4, sort=True)
     self.assertLen(sample, 4)
     self.assertEqual(sample[0].name, 'largest')
@@ -319,36 +238,39 @@ class CorpusTest(tf.test.TestCase):
     self.assertEqual(sample[3].name, 'smol')
 
   def test_filter(self):
-    cps = corpus.Corpus.from_module_specs(module_specs=[
-        corpus.ModuleSpec(name='smol', size=1),
-        corpus.ModuleSpec(name='largest', size=500),
-        corpus.ModuleSpec(name='middle', size=200),
-        corpus.ModuleSpec(name='small', size=100)
-    ])
-
-    new_cps = cps.filter(re.compile(r'.+l'))
-    self.assertLen(cps.module_specs, 4)
-    sample = new_cps.sample(999, sort=True)
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[
+            corpus.CorpusElement(name='smol', size=1),
+            corpus.CorpusElement(name='middle', size=200),
+            corpus.CorpusElement(name='largest', size=500),
+            corpus.CorpusElement(name='small', size=100)
+        ],
+        module_filter=re.compile(r'.+l'))
+    sample = cps.sample(999, sort=True)
     self.assertLen(sample, 3)
     self.assertEqual(sample[0].name, 'middle')
     self.assertEqual(sample[1].name, 'small')
     self.assertEqual(sample[2].name, 'smol')
 
   def test_sample_zero(self):
-    cps = corpus.Corpus.from_module_specs(
-        module_specs=[corpus.ModuleSpec(name='smol')])
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[corpus.CorpusElement(name='smol', size=1)])
 
     self.assertRaises(ValueError, cps.sample, 0)
     self.assertRaises(ValueError, cps.sample, -213213213)
 
   def test_bucket_sample(self):
-    cps = corpus.Corpus.from_module_specs(
-        module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(100)])
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[
+            corpus.CorpusElement(name=f'{i}', size=i) for i in range(100)
+        ])
     # Odds of passing once by pure luck with random.sample: 1.779e-07
     # Try 32 times, for good measure.
     for i in range(32):
-      sample = cps.sample(
-          k=20, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
+      sample = cps.sample(k=20, sort=True)
       self.assertLen(sample, 20)
       for idx, s in enumerate(sample):
         # Each bucket should be size 5, since n=20 in the sampler
@@ -358,13 +280,15 @@ class CorpusTest(tf.test.TestCase):
     # Make sure we can sample everything, even if it's not divisible by the
     # `n` in SamplerBucketRoundRobin.
     # Create corpus with a prime number of modules.
-    cps = corpus.Corpus.from_module_specs(
-        module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(101)])
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[
+            corpus.CorpusElement(name=f'{i}', size=i) for i in range(101)
+        ])
 
     # Try 32 times, for good measure.
     for i in range(32):
-      sample = cps.sample(
-          k=101, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
+      sample = cps.sample(k=101, sort=True)
       self.assertLen(sample, 101)
       for idx, s in enumerate(sample):
         # Since everything is sampled, it should be in perfect order.
@@ -372,13 +296,15 @@ class CorpusTest(tf.test.TestCase):
 
   def test_bucket_sample_small(self):
     # Make sure we can sample even when k < n.
-    cps = corpus.Corpus.from_module_specs(
-        module_specs=[corpus.ModuleSpec(name='', size=i) for i in range(100)])
+    cps = corpus.create_corpus_for_testing(
+        location=self.create_tempdir(),
+        elements=[
+            corpus.CorpusElement(name=f'{i}', size=i) for i in range(100)
+        ])
 
     # Try all 19 possible values 0 < i < n
     for i in range(1, 20):
-      sample = cps.sample(
-          k=i, sampler=corpus.SamplerBucketRoundRobin(), sort=True)
+      sample = cps.sample(k=i, sort=True)
       self.assertLen(sample, i)
 
 

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -67,7 +67,7 @@ class LocalDataCollector(data_collector.DataCollector):
     t1 = time.time()
     sample = self._corpus.sample(k=self._num_modules, sort=False)
     ret = [
-        self._prefetch_pool.submit(self._corpus.load_corpus_element, element)
+        self._prefetch_pool.submit(self._corpus.load_module_spec, element)
         for element in sample
     ]
     logging.info('prefetching took %d', time.time() - t1)

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -59,6 +59,19 @@ class LocalDataCollector(data_collector.DataCollector):
     self._reset_workers: Optional[concurrent.futures.Future] = None
     self._current_futures: List[worker.WorkerFuture] = []
     self._pool = concurrent.futures.ThreadPoolExecutor()
+    self._prefetch_pool = concurrent.futures.ThreadPoolExecutor()
+    self._next_sample: List[
+        concurrent.futures.Future] = self._prefetch_next_sample()
+
+  def _prefetch_next_sample(self):
+    t1 = time.time()
+    sample = self._corpus.sample(k=self._num_modules, sort=False)
+    ret = [
+        self._prefetch_pool.submit(self._corpus.load_corpus_element, element)
+        for element in sample
+    ]
+    logging.info('prefetching took %d', time.time() - t1)
+    return ret
 
   def close_pool(self):
     self._join_pending_jobs()
@@ -80,17 +93,18 @@ class LocalDataCollector(data_collector.DataCollector):
 
   def _schedule_jobs(
       self, policy: policy_saver.Policy,
-      sampled_modules: List[corpus.ModuleSpec]
+      sampled_modules: List[corpus.LoadedModuleSpec]
   ) -> List[worker.WorkerFuture[compilation_runner.CompilationResult]]:
     # by now, all the pending work, which was signaled to cancel, must've
     # finished
     self._join_pending_jobs()
-    jobs = [(module_spec, policy, self._reward_stat_map[module_spec.name])
-            for module_spec in sampled_modules]
+    jobs = [(loaded_module_spec, policy,
+             self._reward_stat_map[loaded_module_spec.name])
+            for loaded_module_spec in sampled_modules]
 
     def work_factory(job):
 
-      def work(w):
+      def work(w: compilation_runner.CompilationRunnerStub):
         return w.collect_data(*job)
 
       return work
@@ -113,7 +127,13 @@ class LocalDataCollector(data_collector.DataCollector):
       They will be reported using `tf.scalar.summary` by the trainer so these
       information is viewable in TensorBoard.
     """
-    sampled_modules = self._corpus.sample(k=self._num_modules, sort=False)
+    time1 = time.time()
+    sampled_modules: List[corpus.LoadedModuleSpec] = [
+        s.result() for s in self._next_sample
+    ]
+    logging.info('resolving prefetched sample took: %d seconds',
+                 time.time() - time1)
+    self._next_sample = self._prefetch_next_sample()
     self._current_futures = self._schedule_jobs(policy, sampled_modules)
 
     def wait_for_termination():

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -109,9 +109,9 @@ class DeterministicSampler(corpus.Sampler):
     self._cur_pos = 0
 
   def __call__(self,
-               module_specs: Tuple[corpus.CorpusElement],
+               module_specs: Tuple[corpus.ModuleSpec],
                k: int,
-               n: int = 20) -> List[corpus.CorpusElement]:
+               n: int = 20) -> List[corpus.ModuleSpec]:
     ret = []
     for _ in range(k):
       ret.append(module_specs[self._cur_pos % len(module_specs)])
@@ -147,7 +147,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
           cps=corpus.create_corpus_for_testing(
               location=self.create_tempdir(),
               elements=[
-                  corpus.CorpusElement(name=f'dummy{i}', size=i)
+                  corpus.ModuleSpec(name=f'dummy{i}', size=i)
                   for i in range(100)
               ],
               sampler=sampler),
@@ -219,7 +219,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
           cps=corpus.create_corpus_for_testing(
               location=self.create_tempdir(),
               elements=[
-                  corpus.CorpusElement(name=f'dummy{i}', size=1)
+                  corpus.ModuleSpec(name=f'dummy{i}', size=1)
                   for i in range(200)
               ]),
           num_modules=4,

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -32,6 +32,7 @@ from compiler_opt.rl import policy_saver
 
 # This is https://github.com/google/pytype/issues/764
 from google.protobuf import text_format  # pytype: disable=pyi-error
+from typing import List, Tuple
 
 _policy_str = 'policy'.encode(encoding='utf-8')
 
@@ -52,8 +53,9 @@ def _get_sequence_example(feature_value):
   return text_format.Parse(sequence_example_text, tf.train.SequenceExample())
 
 
-def mock_collect_data(module_spec, policy, reward_stat):
-  assert module_spec.name == 'dummy'
+def mock_collect_data(loaded_module_spec: corpus.LoadedModuleSpec, policy,
+                      reward_stat):
+  assert loaded_module_spec.name.startswith('dummy')
   assert policy.policy == _policy_str
   assert reward_stat is None or reward_stat == {
       'default':
@@ -85,8 +87,8 @@ def mock_collect_data(module_spec, policy, reward_stat):
 class Sleeper(compilation_runner.CompilationRunner):
   """Test CompilationRunner that just sleeps."""
 
-  def collect_data(self, module_spec, policy, reward_stat):
-    _ = module_spec, policy, reward_stat
+  def collect_data(self, loaded_module_spec, policy, reward_stat):
+    _ = loaded_module_spec, policy, reward_stat
     compilation_runner.start_cancellable_process(['sleep', '3600s'], 3600,
                                                  self._cancellation_manager)
 
@@ -98,6 +100,26 @@ class MyRunner(compilation_runner.CompilationRunner):
 
   def collect_data(self, *args, **kwargs):
     return mock_collect_data(*args, **kwargs)
+
+
+class DeterministicSampler(corpus.Sampler):
+  """A corpus sampler that returns modules in order, and can also be reset."""
+
+  def __init__(self):
+    self._cur_pos = 0
+
+  def __call__(self,
+               module_specs: Tuple[corpus.CorpusElement],
+               k: int,
+               n: int = 20) -> List[corpus.CorpusElement]:
+    ret = []
+    for _ in range(k):
+      ret.append(module_specs[self._cur_pos % len(module_specs)])
+      self._cur_pos += 1
+    return ret
+
+  def reset(self):
+    self._cur_pos = 0
 
 
 class LocalDataCollectorTest(tf.test.TestCase):
@@ -119,14 +141,25 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
       return _test_iterator_fn
 
+    sampler = DeterministicSampler()
     with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          cps=corpus.Corpus.from_module_specs(
-              module_specs=[corpus.ModuleSpec(name='dummy')] * 100),
+          cps=corpus.create_corpus_for_testing(
+              location=self.create_tempdir(),
+              elements=[
+                  corpus.CorpusElement(name=f'dummy{i}', size=i)
+                  for i in range(100)
+              ],
+              sampler=sampler),
           num_modules=9,
           worker_pool=lwp,
           parser=create_test_iterator_fn(),
           reward_stat_map=collections.defaultdict(lambda: None))
+
+      # reset the sampler, so the next time we collect, we collect the same
+      # modules. We do it before the collect_data call, because that's when
+      # we'll re-sample to prefetch the next batch.
+      sampler.reset()
 
       data_iterator, monitor_dict = collector.collect_data(policy=_mock_policy)
       data = list(data_iterator)
@@ -146,9 +179,9 @@ class LocalDataCollectorTest(tf.test.TestCase):
             **monitor_dict,
             **expected_monitor_dict_subset
         })
-
       data_iterator, monitor_dict = collector.collect_data(policy=_mock_policy)
       data = list(data_iterator)
+      # because we reset the sampler, these are the same modules
       self.assertEqual([4, 5, 6], data)
       expected_monitor_dict_subset = {
           'default': {
@@ -183,8 +216,12 @@ class LocalDataCollectorTest(tf.test.TestCase):
 
     with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
-          cps=corpus.Corpus.from_module_specs(
-              module_specs=[corpus.ModuleSpec(name='dummy')] * 200),
+          cps=corpus.create_corpus_for_testing(
+              location=self.create_tempdir(),
+              elements=[
+                  corpus.CorpusElement(name=f'dummy{i}', size=1)
+                  for i in range(200)
+              ]),
           num_modules=4,
           worker_pool=lwp,
           parser=parser,

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -44,12 +44,12 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
   # TODO: refactor file_paths parameter to ensure correctness during
   # construction
   def compile_fn(
-      self, module_spec: corpus.ModuleSpec, tf_policy_path: str,
+      self, command_line: corpus.FullyQualifiedCmdLine, tf_policy_path: str,
       reward_only: bool) -> Dict[str, Tuple[tf.train.SequenceExample, float]]:
     """Run inlining for the given IR file under the given policy.
 
     Args:
-      module_spec: a ModuleSpec.
+      command_line: the fully qualified command line.
       tf_policy_path: path to TF policy direcoty on local disk.
       reward_only: whether only return reward.
 
@@ -73,17 +73,17 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
 
     result = {}
     try:
-      command_line = []
+      cmdline = []
       if self._launcher_path:
-        command_line.append(self._launcher_path)
-      command_line.extend([self._clang_path] + list(module_spec.exec_cmd) + [
+        cmdline.append(self._launcher_path)
+      cmdline.extend([self._clang_path] + list(command_line) + [
           '-mllvm', '-regalloc-enable-advisor=development', '-mllvm',
           '-regalloc-training-log=' + log_path, '-o', output_native_path
       ])
 
       if tf_policy_path:
-        command_line.extend(['-mllvm', '-regalloc-model=' + tf_policy_path])
-      compilation_runner.start_cancellable_process(command_line,
+        cmdline.extend(['-mllvm', '-regalloc-model=' + tf_policy_path])
+      compilation_runner.start_cancellable_process(cmdline,
                                                    self._compilation_timeout,
                                                    self._cancellation_manager)
 

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -100,7 +100,7 @@ def train_eval(agent_name=constant.AgentName.PPO,
 
   logging.info('Loading module specs from corpus at %s.', FLAGS.data_path)
   cps = corpus.Corpus(
-      FLAGS.data_path,
+      data_path=FLAGS.data_path,
       additional_flags=problem_config.flags_to_add(),
       delete_flags=problem_config.flags_to_delete(),
       replace_flags=problem_config.flags_to_replace())

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -77,7 +77,7 @@ def get_runner() -> compilation_runner.CompilationRunner:
 
 
 def worker(policy_path: Optional[str],
-           work_queue: 'queue.Queue[corpus.ModuleSpec]',
+           work_queue: 'queue.Queue[corpus.LoadedModuleSpec]',
            results_queue: 'queue.Queue[ResultsQueueEntry]',
            key_filter: Optional[str]):
   """Describes the job each paralleled worker process does.
@@ -101,15 +101,17 @@ def worker(policy_path: Optional[str],
         policy_path) if policy_path else None
     while True:
       try:
-        module_spec = work_queue.get_nowait()
+        loaded_module_spec = work_queue.get_nowait()
       except queue.Empty:
         return
       try:
         data = runner.collect_data(
-            module_spec=module_spec, policy=policy, reward_stat=None)
+            loaded_module_spec=loaded_module_spec,
+            policy=policy,
+            reward_stat=None)
         if not m:
           results_queue.put(
-              (module_spec.name, data.serialized_sequence_examples,
+              (loaded_module_spec.name, data.serialized_sequence_examples,
                data.reward_stats))
           continue
         new_reward_stats = {}
@@ -121,10 +123,10 @@ def worker(policy_path: Optional[str],
           new_reward_stats[k] = data.reward_stats[k]
           new_sequence_examples.append(sequence_example)
         results_queue.put(
-            (module_spec.name, new_sequence_examples, new_reward_stats))
+            (loaded_module_spec.name, new_sequence_examples, new_reward_stats))
       except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
               RuntimeError):
-        logging.error('Failed to compile %s.', module_spec.name)
+        logging.error('Failed to compile %s.', loaded_module_spec.name)
         results_queue.put(None)
   except BaseException as e:  # pylint: disable=broad-except
     results_queue.put(e)
@@ -139,22 +141,22 @@ def main(_):
   config = registry.get_configuration()
 
   logging.info('Loading module specs from corpus.')
+  module_filter = re.compile(
+      _MODULE_FILTER.value) if _MODULE_FILTER.value else None
+
   cps = corpus.Corpus(
-      _DATA_PATH.value,
+      data_path=_DATA_PATH.value,
+      module_filter=module_filter,
       additional_flags=config.flags_to_add(),
       delete_flags=config.flags_to_delete(),
       replace_flags=config.flags_to_replace())
   logging.info('Done loading module specs from corpus.')
 
-  if _MODULE_FILTER.value:
-    m = re.compile(_MODULE_FILTER.value)
-    cps = cps.filter(m)
-
   # Sampling if needed.
   sampled_modules = int(len(cps) * _SAMPLING_RATE.value)
   # sort files by size, to process the large files upfront, hopefully while
   # other smaller files are processed in parallel
-  module_specs = cps.sample(k=sampled_modules, sort=True)
+  corpus_elements = cps.sample(k=sampled_modules, sort=True)
 
   worker_count = (
       min(os.cpu_count(), _NUM_WORKERS.value)
@@ -172,9 +174,9 @@ def main(_):
       ctx = multiprocessing.get_context()
       m = ctx.Manager()
       results_queue: 'queue.Queue[ResultsQueueEntry]' = m.Queue()
-      work_queue: 'queue.Queue[corpus.ModuleSpec]' = m.Queue()
-      for module_spec in module_specs:
-        work_queue.put(module_spec)
+      work_queue: 'queue.Queue[corpus.LoadedModuleSpec]' = m.Queue()
+      for corpus_element in corpus_elements:
+        work_queue.put(cps.load_corpus_element(corpus_element))
 
       # pylint:disable=g-complex-comprehension
       processes = [
@@ -189,7 +191,7 @@ def main(_):
         p.start()
 
       total_successful_examples = 0
-      total_work = len(module_specs)
+      total_work = len(corpus_elements)
       total_failed_examples = 0
       total_training_examples = 0
       for _ in range(total_work):
@@ -217,7 +219,7 @@ def main(_):
                 (f'{module_name},{key},{value.default_reward},'
                  f'{value.moving_average_reward}\n'))
 
-      print((f'{total_successful_examples} of {len(module_specs)} modules '
+      print((f'{total_successful_examples} of {len(corpus_elements)} modules '
              f'succeeded, and {total_training_examples} trainining examples '
              'written'))
       for p in processes:

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -176,7 +176,7 @@ def main(_):
       results_queue: 'queue.Queue[ResultsQueueEntry]' = m.Queue()
       work_queue: 'queue.Queue[corpus.LoadedModuleSpec]' = m.Queue()
       for corpus_element in corpus_elements:
-        work_queue.put(cps.load_corpus_element(corpus_element))
+        work_queue.put(cps.load_module_spec(corpus_element))
 
       # pylint:disable=g-complex-comprehension
       processes = [

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -36,7 +36,7 @@ flags.FLAGS['gin_bindings'].allow_override = True
 class MockCompilationRunner(compilation_runner.CompilationRunner):
   """A compilation runner just for test."""
 
-  def collect_data(self, module_spec, policy, reward_stat):
+  def collect_data(self, loaded_module_spec, policy, reward_stat):
     sequence_example_text = """
       feature_lists {
         feature_list {


### PR DESCRIPTION
This change removes the assumption that the corpus is co-located with the workers. The new design relies on the assumption that the workers are reachable via a high-throughput network (datacenter setup). The trainer prefetches the modules for the next iteration and sends them as data blobs to the workers.

The rest of the change trickles out from this:

- the corpus operates internally with a metadata object about modules, `CorpusElement`
- workers are given a `LoadedModuleSpec` which contains the data of the module (and its thinlto index, if needed).
- command line final shape is done on the worker side

This had the side-effect that responsibilities could be reassigned as follows:

- the corpus constructor handles preparing the `CorpusElement`s, with all the necessary flag modification handlers (i.e. add/delete/replace)
- flag modification logic is generic - it doesn't know anything about thinlto, '-cc1', etc

In turn, this impacted testing.

This change impacts purely local training similar to how a previous change remoting the policy does - local files are copied by workers redundantly. It doesn not appear to have any impact on training performance, but should we want to, we can optimize the local scenario under the hood.