### PR TITLE
Removed num_modules flag from RL training in demo

### DIFF
--- a/docs/demo/demo.md
+++ b/docs/demo/demo.md
@@ -308,7 +308,6 @@ rm -rf $OUTPUT_DIR && \
   --data_path=$CORPUS \
   --gin_bindings=clang_path="'$LLVM_INSTALLDIR/bin/clang'" \
   --gin_bindings=llvm_size_path="'$LLVM_INSTALLDIR/bin/llvm-size'" \
-  --num_modules=100 \
   --gin_files=compiler_opt/rl/inlining/gin_configs/ppo_nn_agent.gin \
   --gin_bindings=train_eval.warmstart_policy_dir=\"$WARMSTART_OUTPUT_DIR/saved_policy\"
 ```


### PR DESCRIPTION
We refactored this flag a while ago to be specified in the gin config for the relevant problem to improve reproducibility, especially in the regalloc case, but I forgot to remove the flag from the demo. This patch removes the flag from the demo, making everything (hopefully) plug and play.