### PR TITLE
Removed tensorflow_c_lib_path flag from LLVM build for benchmarking

### DIFF
--- a/compiler_opt/benchmark/benchmark_chromium.py
+++ b/compiler_opt/benchmark/benchmark_chromium.py
@@ -30,7 +30,6 @@ PYTHONPATH=$PYTHONPATH:. python3 \
   --llvm_build_path=/llvm-build \
   --compile_llvm \
   --model_path=/tmp/model \
-  --tensorflow_c_lib_path=/tmp/tensorflow \
   --chromium_build_path=./out/Release \
   --output_file=./output.json \
   --perf_counters=mem_uops_retired.all_loads \
@@ -89,9 +88,6 @@ flags.DEFINE_string('llvm_source_path', '/llvm-project',
                     'The root path of your local llvm-project checkout')
 flags.DEFINE_string('model_path', '',
                     'The path to the model to use when compiling llvm')
-flags.DEFINE_string(
-    'tensorflow_c_lib_path', '/tmp/tensorflow',
-    'The path to an extracted copy of the tensorflow c library')
 flags.DEFINE_string(
     'chromium_build_path', './out/Release',
     'The chromium build path, relative to the chromium source'
@@ -210,8 +206,7 @@ def main(_):
 
   if FLAGS.compile_llvm:
     benchmarking_utils.build_llvm(FLAGS.model_path, FLAGS.llvm_use_incremental,
-                                  FLAGS.llvm_build_path, FLAGS.llvm_source_path,
-                                  FLAGS.tensorflow_c_lib_path)
+                                  FLAGS.llvm_build_path, FLAGS.llvm_source_path)
 
   if FLAGS.compile_tests:
     build_chromium_tests(FLAGS.advisor, FLAGS.chromium_build_path,

--- a/compiler_opt/benchmark/benchmark_llvm_test_suite.py
+++ b/compiler_opt/benchmark/benchmark_llvm_test_suite.py
@@ -33,7 +33,6 @@ PYTHONPATH=$PYTHONPATH:. \
   --llvm_build_path=/llvm-build \
   --llvm_source_path=/llvm-project \
   --llvm_test_suite_build_path=/llvm-test-suite/build \
-  --tensorflow_c_lib_path=/tmp/tensorflow \
   --perf_counter=INSTRUCTIONS \
   --perf_counter=MEM_UOPS_RETIRED:ALL_LOADS \
   --perf_counter=MEM_UOPS_RETIRED:ALL_STORES
@@ -96,8 +95,6 @@ flags.DEFINE_string('llvm_source_path', '/llvm-project',
                     'The path to the root of the llvm-project repositoy')
 flags.DEFINE_string('llvm_test_suite_build_path', None,
                     'The path to the llvm test suite build')
-flags.DEFINE_string('tensorflow_c_lib_path', '/tmp/tensorflow',
-                    'The path to the tensorflow c lib library')
 flags.DEFINE_multi_string(
     'tests_to_run', default_tests,
     'Tests compiled with google benchmark to run,'
@@ -189,8 +186,7 @@ def main(_):
                                                     './build')
   if FLAGS.compile_llvm:
     benchmarking_utils.build_llvm(FLAGS.model_path, FLAGS.llvm_use_incremental,
-                                  FLAGS.llvm_build_path, FLAGS.llvm_source_path,
-                                  FLAGS.tensorflow_c_lib_path)
+                                  FLAGS.llvm_build_path, FLAGS.llvm_source_path)
   if FLAGS.compile_testsuite:
     build_test_suite(FLAGS.advisor, FLAGS.llvm_test_suite_build_path,
                      FLAGS.llvm_build_path, FLAGS.llvm_test_suite_path)

--- a/compiler_opt/benchmark/benchmarking_utils.py
+++ b/compiler_opt/benchmark/benchmarking_utils.py
@@ -25,8 +25,7 @@ from typing import Optional, List
 
 
 def build_llvm(model_path: str, use_existing_build: bool, llvm_build_path: str,
-               llvm_source_path: Optional[str],
-               tensorflow_c_lib_path: Optional[str]):
+               llvm_source_path: Optional[str]):
   """Builds LLVM/clang with the specified model and the correct settings
 
   This function invokes CMake with all the correct build flags specified
@@ -60,9 +59,7 @@ def build_llvm(model_path: str, use_existing_build: bool, llvm_build_path: str,
     tensorflow_aot_path = os.path.dirname(tensorflow.__file__)
     cmake_config_command.extend([
         "-DCMAKE_BUILD_TYPE=Release",
-        f"-DTENSORFLOW_C_LIB_PATH={tensorflow_c_lib_path}",
         f"-DTENSORFLOW_AOT_PATH='{tensorflow_aot_path}'",
-        "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON",
         "-DLLVM_ENABLE_PROJECTS='clang;lld'",
         "-DLLVM_ENABLE_RUNTIMES='compiler-rt'", f"{llvm_source_path}"
     ])


### PR DESCRIPTION
Should help with the other half of #129. The benchmarking code currently sets the TENSORFLOW_C_LIB_PATH CMake variable when building LLVM. However, this doesn't make sense going forward as we have shifted mostly everything over to TFLite and we don't need to have MLGO development mode enabled for benchmarking in either case. This patch explicitly removes the flag so that the benchmarks simply build LLVM in MLGO release mode.