### PR TITLE
Have the worker pool context produce a pool object

### DIFF
--- a/compiler_opt/distributed/local/local_worker_manager_test.py
+++ b/compiler_opt/distributed/local/local_worker_manager_test.py
@@ -62,9 +62,9 @@ class LocalWorkerManagerTest(absltest.TestCase):
 
   def test_pool(self):
 
-    with local_worker_manager.LocalWorkerPool(JobNormal, 2) as pool:
-      p1 = pool[0]
-      p2 = pool[1]
+    with local_worker_manager.LocalWorkerPoolManager(JobNormal, 2) as pool:
+      p1 = pool.get_currently_active()[0]
+      p2 = pool.get_currently_active()[1]
       set_futures = [p1.set_token(1), p2.set_token(2)]
       done, not_done = concurrent.futures.wait(set_futures)
       self.assertLen(done, 2)
@@ -81,16 +81,16 @@ class LocalWorkerManagerTest(absltest.TestCase):
 
   def test_failure(self):
 
-    with local_worker_manager.LocalWorkerPool(JobFail, 2) as pool:
+    with local_worker_manager.LocalWorkerPoolManager(JobFail, 2) as pool:
       with self.assertRaises(concurrent.futures.CancelledError):
         # this will fail because we didn't pass the arg to the ctor, so the
         # worker hosting process will crash.
-        pool[0].method().result()
+        pool.get_currently_active()[0].method().result()
 
   def test_worker_crash_while_waiting(self):
 
-    with local_worker_manager.LocalWorkerPool(JobSlow, 2) as pool:
-      p = pool[0]
+    with local_worker_manager.LocalWorkerPoolManager(JobSlow, 2) as pool:
+      p = pool.get_currently_active()[0]
       f = p.method()
       self.assertFalse(f.done())
       try:

--- a/compiler_opt/distributed/worker.py
+++ b/compiler_opt/distributed/worker.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """Common abstraction for a worker contract."""
 
-from typing import Iterable, Optional, Protocol, TypeVar
+import abc
+from typing import Any, List, Iterable, Optional, Protocol, TypeVar
 
 
 class Worker(Protocol):
@@ -26,6 +27,34 @@ class Worker(Protocol):
 
 
 T = TypeVar('T')
+
+
+class WorkerPool(metaclass=abc.ABCMeta):
+  """Abstraction of a pool of workers that may be refreshed."""
+
+  # Issue #155 would strongly-type the return type.
+  @abc.abstractmethod
+  def get_currently_active(self) -> List[Any]:
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def get_worker_concurrency(self) -> int:
+    raise NotImplementedError()
+
+
+class FixedWorkerPool(WorkerPool):
+  """A WorkerPool built from a fixed list of workers."""
+
+  # Issue #155 would strongly-type `workers`
+  def __init__(self, workers: List[Any], worker_concurrency: int = 2):
+    self._workers = workers
+    self._worker_concurrency = worker_concurrency
+
+  def get_currently_active(self):
+    return self._workers
+
+  def get_worker_concurrency(self):
+    return self._worker_concurrency
 
 
 # Dask's Futures are limited. This captures that.

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -23,7 +23,7 @@ import sys
 import tensorflow as tf
 from tf_agents.system import system_multiprocessing as multiprocessing
 
-from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPool
+from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPoolManager
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import corpus
 from compiler_opt.rl import data_collector
@@ -142,7 +142,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
       return _test_iterator_fn
 
     sampler = DeterministicSampler()
-    with LocalWorkerPool(worker_class=MyRunner, count=4) as lwp:
+    with LocalWorkerPoolManager(worker_class=MyRunner, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
           cps=corpus.create_corpus_for_testing(
               location=self.create_tempdir(),
@@ -214,7 +214,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
       def wait(self, _):
         return False
 
-    with LocalWorkerPool(worker_class=Sleeper, count=4) as lwp:
+    with LocalWorkerPoolManager(worker_class=Sleeper, count=4) as lwp:
       collector = local_data_collector.LocalDataCollector(
           cps=corpus.create_corpus_for_testing(
               location=self.create_tempdir(),

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -29,7 +29,7 @@ from tf_agents.agents import tf_agent
 from tf_agents.system import system_multiprocessing as multiprocessing
 from typing import List
 
-from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPool
+from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPoolManager
 from compiler_opt.rl import agent_creators
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import constant
@@ -59,7 +59,7 @@ FLAGS = flags.FLAGS
 
 
 @gin.configurable
-def train_eval(worker_manager_class=LocalWorkerPool,
+def train_eval(worker_manager_class=LocalWorkerPoolManager,
                agent_name=constant.AgentName.PPO,
                warmstart_policy_dir=None,
                num_policy_iterations=0,


### PR DESCRIPTION
The motivation is:
- allowing worker managers specify the level of concurrency for a worker. This is set to '10' right now by the data collector, but it's really specific to the worker set up. For the local case, where we max out the hardware threads with workers, 10 is overly-generous. For a distributed case, a number approaching the hardware threads would be more appropriate
- allowing distributed worker managers update the set of available workers over time. Workers could get preempted, or new ones become available. Having a way to periodically check and update what's available - albeit there are never guarantees a worker, once discovered, stays alive - helps avoid artificial starvation.

The rest is renames that fall out of this refactoring.