### PR TITLE
Update the Dockerfiles to use a base image supported by Fuchsia infra.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM debian:bullseye
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-is-python3 \
     python3 \


### PR DESCRIPTION
The current base image, Ubuntu 22.04LTS has a much newer kernel and glibc. Fuchsia infra builders is running into issues to support it. This patch changes the base image to debian bullseye which aligns with what infra builders use.

This change will drops the python revision from 3.10 to 3.9.