### PR TITLE
Escape '{' '}' brackets in original command line

### DIFF
--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -315,7 +315,8 @@ class Corpus:
         ret = cmd_override
       else:
         with tf.io.gfile.GFile(os.path.join(data_path, name + '.cmd')) as f:
-          ret = tuple(f.read().split('\0'))
+          ret = tuple(f.read().replace(r'{', r'{{').replace(r'}',
+                                                            r'}}').split('\0'))
           # The options read from a .cmd file must be run with -cc1
           if ret[0] != '-cc1':
             raise ValueError('-cc1 flag not present in .cmd file.')


### PR DESCRIPTION
It's possible the original command line has brackets that otherwise python string formatting will interpret as part of the worker contextualization formatting (i.e. LoadedModuleSpec.build_command_line). We need to escape such brackets upfront when loading the command line.