### PR TITLE
Convenience: allow specifying the corpus description json file

### DIFF
--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -105,6 +105,17 @@ class CorpusTest(tf.test.TestCase):
         has_thinlto=False),))
     self.assertEqual(len(cps), 1)
 
+  def test_specific_path(self):
+    basedir = self.create_tempdir()
+    cps = corpus.create_corpus_for_testing(
+        location=basedir, elements=[corpus.ModuleSpec(name='1', size=1)])
+    new_corpus_desc = os.path.join(basedir, 'hi.json')
+    tf.io.gfile.rename(
+        os.path.join(basedir, corpus.DEFAULT_CORPUS_DESCRIPTION_FILENAME),
+        new_corpus_desc)
+    cps2 = corpus.Corpus(location=new_corpus_desc)
+    self.assertTupleEqual(cps.module_specs, cps2.module_specs)
+
   def test_invalid_args(self):
     with self.assertRaises(
         ValueError, msg='-cc1 flag not present in .cmd file'):

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -45,8 +45,10 @@ from compiler_opt.rl import trainer
 
 flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
                     'Root directory for writing logs/summaries/checkpoints.')
-flags.DEFINE_string('data_path', None,
-                    'Path to directory containing the corpus.')
+flags.DEFINE_string(
+    'data_path', None,
+    'Path to directory containing the corpus, or specific corpus description '
+    'json file.')
 flags.DEFINE_integer(
     'num_workers', None,
     'Number of parallel data collection workers. `None` for max available')
@@ -103,7 +105,7 @@ def train_eval(worker_manager_class=LocalWorkerPoolManager,
 
   logging.info('Loading module specs from corpus at %s.', FLAGS.data_path)
   cps = corpus.Corpus(
-      data_path=FLAGS.data_path,
+      location=FLAGS.data_path,
       additional_flags=problem_config.flags_to_add(),
       delete_flags=problem_config.flags_to_delete(),
       replace_flags=problem_config.flags_to_replace())

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -37,8 +37,10 @@ from compiler_opt.rl import registry
 # see https://bugs.python.org/issue33315 - we do need these types, but must
 # currently use them as string annotations
 
-_DATA_PATH = flags.DEFINE_string('data_path', None,
-                                 'Path to folder containing IR files.')
+_DATA_PATH = flags.DEFINE_string(
+    'data_path', None,
+    'Path to directory containing IR files, or path to description json file '
+    'under such a directory.')
 _POLICY_PATH = flags.DEFINE_string(
     'policy_path', '', 'Path to the policy to generate trace with.')
 _OUTPUT_PATH = flags.DEFINE_string(
@@ -145,7 +147,7 @@ def main(_):
       _MODULE_FILTER.value) if _MODULE_FILTER.value else None
 
   cps = corpus.Corpus(
-      data_path=_DATA_PATH.value,
+      location=_DATA_PATH.value,
       module_filter=lambda name: True
       if not module_filter else module_filter.match(name),
       additional_flags=config.flags_to_add(),


### PR DESCRIPTION
I found it useful sometimes to have variations of the corpus description - e.g. remove swaths of modules. This patch allows multiple descriptions to co-exist under a corpus directory, and select the desired one transparently.

Renamed the ctor argument since "data path" is more of a directory than a file, "location" covers both cases.