### PR TITLE
Use the official Python image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM debian:bullseye
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python-is-python3 \
-    python3 \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.9
+
 COPY . /ml-compiler-opt
-RUN python3 -m pip install -r /ml-compiler-opt/requirements.txt
+RUN pip install --no-cache-dir -r /ml-compiler-opt/requirements.txt
+
+WORKDIR /ml-compiler-opt/compiler_opt/tools
 ENV PYTHONPATH=/ml-compiler-opt
+
 VOLUME /external


### PR DESCRIPTION
This gives more precise control over the Python version.