### PR TITLE
Prepare for distributed training infrastructure.

### DIFF
--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -311,7 +311,8 @@ class CompilationRunner(Worker):
                launcher_path: Optional[str] = None,
                moving_average_decay_rate: float = 1,
                compilation_timeout=None,
-               create_observer_fns: Optional[List[Callable]] = None):
+               create_observer_fns: Optional[List[Callable[
+                   [], CompilationResultObserver]]] = None):
     """Initialization of CompilationRunner class.
 
     Args:

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -332,8 +332,8 @@ class CompilationRunner(Worker):
     self._compilation_timeout = (
         compilation_timeout or _COMPILATION_TIMEOUT.value)
     self._cancellation_manager = WorkerCancellationManager()
-    self._observers = [f() for f in create_observer_fns
-                      ] if create_observer_fns else []
+    self._observers = ([f() for f in create_observer_fns]
+                       if create_observer_fns else [])
 
   # re-allow the cancellation manager accept work.
   def enable(self):

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -21,7 +21,7 @@ import signal
 import subprocess
 import tempfile
 import threading
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from absl import flags
 from absl import logging
@@ -276,6 +276,27 @@ class CompilationRunnerStub(metaclass=abc.ABCMeta):
     raise NotImplementedError()
 
 
+class CompilationResultObserver(metaclass=abc.ABCMeta):
+  """Abstract base class used to observe compilation results.
+
+  This is indended for users who need to observe compilations while they are in
+  the distributed worker pool, rather than after they have been coalesced in
+  the collection script.
+  """
+
+  @abc.abstractmethod
+  def observe(self, result: CompilationResult) -> None:
+    """Observe a compilation result.
+
+    Note that this will be executed on the worker in the pool rather than on
+    the coordinator.
+
+    Args:
+      result: the compilation result to observe
+    """
+    pass
+
+
 class CompilationRunner(Worker):
   """Base class for collecting compilation data."""
 
@@ -289,13 +310,20 @@ class CompilationRunner(Worker):
                clang_path: Optional[str] = None,
                launcher_path: Optional[str] = None,
                moving_average_decay_rate: float = 1,
-               compilation_timeout=None):
+               compilation_timeout=None,
+               create_observer_fns: Optional[List[Callable]] = None):
     """Initialization of CompilationRunner class.
 
     Args:
       clang_path: path to the clang binary.
       launcher_path: path to the launcher binary.
       moving_average_decay_rate: moving average decay rate during training.
+      create_observer_fns: list of callables which are used to create
+        CompilationResultObserver objects. We pass the create callables instead
+        of the actual objects because the callables are "just code" and likely
+        able to be pickled/sent to the workers, whereas the observers might
+        contain non-picklable attributes, such as server connections. It is
+        typed as Optional[List[]] due to W0102 dangerous-default-value.
     """
     self._clang_path = clang_path
     self._launcher_path = launcher_path
@@ -304,6 +332,8 @@ class CompilationRunner(Worker):
     self._compilation_timeout = (
         compilation_timeout or _COMPILATION_TIMEOUT.value)
     self._cancellation_manager = WorkerCancellationManager()
+    self._observers = [f() for f in create_observer_fns
+                      ] if create_observer_fns else []
 
   # re-allow the cancellation manager accept work.
   def enable(self):
@@ -388,13 +418,18 @@ class CompilationRunner(Worker):
       policy_rewards.append(policy_reward)
       keys.append(k)
 
-    return CompilationResult(
+    result = CompilationResult(
         sequence_examples=sequence_example_list,
         reward_stats=reward_stat,
         rewards=rewards,
         policy_rewards=policy_rewards,
         keys=keys,
         model_id=model_id)
+
+    for observer in self._observers:
+      observer.observe(result)
+
+    return result
 
   def compile_fn(
       self, command_line: corpus.FullyQualifiedCmdLine, tf_policy_path: str,

--- a/compiler_opt/rl/constant.py
+++ b/compiler_opt/rl/constant.py
@@ -35,6 +35,7 @@ class AgentName(enum.Enum):
   BEHAVIORAL_CLONE = 0
   DQN = 1
   PPO = 2
+  PPO_DISTRIBUTED = 3
 
 
 class DataClassJSONEncoder(json.JSONEncoder):

--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -47,6 +47,6 @@ class ConstantValueNetwork(network.Network):
 
   def call(self, inputs, step_type=None, network_state=(), training=False):
     _ = (step_type, training)
-    shape = nest_utils.get_outer_array_shape(inputs, self._input_tensor_spec)
-    return tf.constant(
-        self._constant_output_val, tf.float32, shape=shape), network_state
+    shape = nest_utils.get_outer_shape(inputs, self._input_tensor_spec)
+    constant = tf.constant(self._constant_output_val, tf.float32)
+    return tf.fill(shape, constant), network_state

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -32,7 +32,7 @@ def _get_policy_info_parsing_dict(agent_name, action_spec):
           'CategoricalProjectionNetwork_logits':
               tf.io.FixedLenSequenceFeature(
                   shape=(action_spec.maximum - action_spec.minimum + 1),
-                  dtype=tf.float32),
+                  dtype=tf.float32)
       }
     else:
       return {
@@ -62,7 +62,7 @@ def _process_parsed_sequence_and_get_policy_info(parsed_sequence, agent_name,
       policy_info = {
           'dist_params': {
               'logits': parsed_sequence['CategoricalProjectionNetwork_logits']
-          },
+          }
       }
       del parsed_sequence['CategoricalProjectionNetwork_logits']
     else:

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -28,16 +28,12 @@ def _get_policy_info_parsing_dict(agent_name, action_spec):
   """Function to get parsing dict for policy info."""
   if agent_name in (constant.AgentName.PPO, constant.AgentName.PPO_DISTRIBUTED):
     if tensor_spec.is_discrete(action_spec):
-      parsing_dict = {
+      return {
           'CategoricalProjectionNetwork_logits':
               tf.io.FixedLenSequenceFeature(
                   shape=(action_spec.maximum - action_spec.minimum + 1),
                   dtype=tf.float32),
       }
-      if agent_name == constant.AgentName.PPO_DISTRIBUTED:
-        parsing_dict['value_prediction'] = tf.io.FixedLenSequenceFeature(
-            shape=(), dtype=tf.float32)
-      return parsing_dict
     else:
       return {
           'NormalProjectionNetwork_scale':
@@ -69,9 +65,6 @@ def _process_parsed_sequence_and_get_policy_info(parsed_sequence, agent_name,
           },
       }
       del parsed_sequence['CategoricalProjectionNetwork_logits']
-      if agent_name == constant.AgentName.PPO_DISTRIBUTED:
-        policy_info['value_prediction'] = parsed_sequence['value_prediction']
-        del parsed_sequence['value_prediction']
     else:
       policy_info = {
           'dist_params': {

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -150,10 +150,11 @@ def create_parser_fn(agent_name: constant.AgentName,
   return _parser_fn
 
 
-def create_flat_sequence_example_dataset_fn(agent_name: constant.AgentName,
-                                            time_step_spec: types.NestedSpec,
-                                            action_spec: types.NestedSpec,
-                                            is_greedy: bool = False):
+def create_flat_sequence_example_dataset_fn(
+    agent_name: constant.AgentName,
+    time_step_spec: types.NestedSpec,
+    action_spec: types.NestedSpec,
+    is_greedy: bool = False) -> Callable[[List[str]], tf.data.Dataset]:
   """Get a function that creates a dataset from serialized sequence examples.
 
   The dataset is "flat" insofar as it does not batch for sequence length nor

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -47,9 +47,6 @@ def _define_sequence_example(agent_name, is_action_discrete):
         example.feature_lists.feature_list[
             'CategoricalProjectionNetwork_logits'].feature.add(
             ).float_list.value.extend([1.2, 3.4])
-        if agent_name == constant.AgentName.PPO_DISTRIBUTED:
-          example.feature_lists.feature_list['value_prediction'].feature.add(
-          ).float_list.value.extend([4.5])
       else:
         example.feature_lists.feature_list[
             'NormalProjectionNetwork_scale'].feature.add(
@@ -161,10 +158,6 @@ class DataReaderTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllClose([[[1.2, 3.4], [1.2, 3.4], [1.2, 3.4]],
                          [[1.2, 3.4], [1.2, 3.4], [1.2, 3.4]]],
                         experience.policy_info['dist_params']['logits'])
-
-    if agent_name == constant.AgentName.PPO_DISTRIBUTED:
-      self.assertAllClose([[4.5, 4.5, 4.5], [4.5, 4.5, 4.5]],
-                          experience.policy_info['value_prediction'])
 
   @parameterized.named_parameters(
       ('SequenceExampleDatasetFn',

--- a/compiler_opt/rl/feature_ops.py
+++ b/compiler_opt/rl/feature_ops.py
@@ -42,7 +42,8 @@ def build_quantile_map(quantile_file_dir: str):
 
 def discard_fn(obs: types.Float):
   """discard the input feature by setting it to 0."""
-  return tf.zeros(shape=obs.shape + [0], dtype=tf.float32)
+  zeros = tf.zeros_like(obs, dtype=tf.float32)
+  return tf.expand_dims(zeros, axis=-1)
 
 
 def identity_fn(obs: types.Float):

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -61,7 +61,7 @@ class FeatureUtilsTest(tf.test.TestCase, parameterized.TestCase):
     obs = tf.constant(value=[[2.0], [8.0]])
     output = feature_ops.discard_fn(obs)
 
-    self.assertAllEqual([2, 1, 0], output.shape)
+    self.assertAllEqual([2, 1, 1], output.shape)
 
   def test_identity_fn(self):
     # obs in shape of [2, 1].


### PR DESCRIPTION
Distributed training has slightly different requirements than our current setup. This commit includes some small changes to prepare for the distributed training commit.

Relevant changes:
 - add ability to observe compilation results within each worker (this will be used to efficiently send experiences to reverb). This is intended for users who need to observe compilations while they are in the distributed worker pool, rather than after they have been coalesced in the collection script.


 - add a sequence example dataset creator which doesn't batch examples (reverb does not handle batched examples).

 - slightly change the parsing logic to handle distributed PPO evaluation and training. In particular, distributed training requires that compute_value_and_advantage_in_train=False, which changes the policy_info spec that we require. Similarly, when evaluating the policy we convert the collect policy parameters stored on reverb to a greedy policy, which requires slightly changing how we parse data. Nothing changes in the "default" training case.

 - add a "model_id" parameter for collect_data() which is used to correctly tag experiences with the model which collected them during distributed training. This is used to ensure that the PPO training remains on-policy in the distributed setting.

 - change the ConstantValueNetwork to determine its output shape dynamically based on the input shape.