### PR TITLE
Bumped setup-python version to fix Github CI deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,14 +49,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Python With Cached pip Packages
         if: needs.Envvars.outputs.do_cache == '1'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install Python, no cache
         if: needs.Envvars.outputs.do_cache == '0'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -r requirements-ci.txt -q


### PR DESCRIPTION
CI currently is giving a lot of deprecation warnings of the form:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
Due to using an old version of the `setup-python` action. This PR bumps the `setup-python` version to v4 so that the action doesn't use the deprecated path anymore, thus getting rid of the deprecation warning.