### PR TITLE
Add a model_id parameter to collect_data.

### DIFF
--- a/compiler_opt/rl/data_collector.py
+++ b/compiler_opt/rl/data_collector.py
@@ -52,12 +52,13 @@ class DataCollector(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def collect_data(
-      self, policy: policy_saver.Policy
+      self, policy: policy_saver.Policy, model_id: int
   ) -> Tuple[Iterator[trajectory.Trajectory], Dict[str, Dict[str, float]]]:
     """Collect data for a given policy.
 
     Args:
       policy_path: the path to the policy directory to collect data with.
+      model_id: the id of the model used to collect data.
 
     Returns:
       An iterator of batched trajectory.Trajectory that are ready to be fed to
@@ -126,7 +127,7 @@ class EarlyExitChecker:
 
     Args:
       get_num_finished_work: a callable object which returns the amount of
-      finished work.
+        finished work.
 
     Returns:
       The amount of time waited.

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -176,7 +176,8 @@ def train_eval(worker_manager_class=LocalWorkerPoolManager,
 
       dataset_iter, monitor_dict = data_collector.collect_data(
           policy=policy_saver.Policy.from_filesystem(
-              os.path.join(policy_path, deploy_policy_name)))
+              os.path.join(policy_path, deploy_policy_name)),
+          model_id=llvm_trainer.global_step_numpy())
       llvm_trainer.train(dataset_iter, monitor_dict, num_iterations)
 
       data_collector.on_dataset_consumed(dataset_iter)

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -108,7 +108,8 @@ def worker(policy_path: Optional[str],
         data = runner.collect_data(
             loaded_module_spec=loaded_module_spec,
             policy=policy,
-            reward_stat=None)
+            reward_stat=None,
+            model_id=0)
         if not m:
           results_queue.put(
               (loaded_module_spec.name, data.serialized_sequence_examples,

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -36,7 +36,7 @@ flags.FLAGS['gin_bindings'].allow_override = True
 class MockCompilationRunner(compilation_runner.CompilationRunner):
   """A compilation runner just for test."""
 
-  def collect_data(self, loaded_module_spec, policy, reward_stat):
+  def collect_data(self, loaded_module_spec, policy, reward_stat, model_id):
     sequence_example_text = """
       feature_lists {
         feature_list {
@@ -59,7 +59,8 @@ class MockCompilationRunner(compilation_runner.CompilationRunner):
         },
         rewards=[1.2],
         policy_rewards=[18],
-        keys=['default'])
+        keys=['default'],
+        model_id=model_id)
 
 
 class GenerateDefaultTraceTest(absltest.TestCase):


### PR DESCRIPTION
The model_id parameter allows joining compilation results with the model used during the compilation. This is useful for debugging errors in training as well as for ensuring experience freshness in the distributed training setting.