### PR TITLE
Fail fast in IR extraction if using local thinLTO and an input

### DIFF
--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -320,6 +320,8 @@ def main(argv):
   flags.mark_flags_as_required(['output_dir'])
 
   objs = []
+  if FLAGS.input is not None and FLAGS.thinlto_build == 'local':
+    raise ValueError('--thinlto_build=local cannot be run with --input')
   if FLAGS.input is None:
     if FLAGS.thinlto_build != 'local':
       raise ValueError('--input or --thinlto_build=local must be provided')


### PR DESCRIPTION
ThinTLO corpus extraction in extract_ir.py is designed to be used without an input file (ie an lld params file or a
compile_commands.json). However, if the user passes in an input while trying to do local thinLTO corpus extraction the extraction might partially succeed, or even fully succeed without giving any indication of what might be amiss. This patch makes these configurations error out to reduce confusion.

Follow up patch to conversation on Slack with Mircea about this issue.