### PR TITLE
Fixed demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Strategies to train policies. Currently, this repository only support Policy
 Gradient training. The release of Evolution Strategies training is on our
 roadmap.
 
-Check out this [demo](docs/demo/demo.md) for an end-to-end demonstration of how
+Check out this [demo](docs/inlining-demo/demo.md) for an end-to-end demonstration of how
 to train your own inlining-for-size policy from the scratch with Policy
-Gradient.
+Gradient, or check out this [demo](docs/regalloc-demo/demo.md) for a demonstration of how
+to train your own regalloc-for-performance policy.
 
 For more details about MLGO, please refer to our paper
 [MLGO: a Machine Learning Guided Compiler Optimizations Framework](https://arxiv.org/abs/2101.04808).

--- a/docs/adding_features.md
+++ b/docs/adding_features.md
@@ -27,7 +27,7 @@ For each policy we train, there should be a `config.py`, e.g. `compiler_opt/rl/i
 
 First and foremost, **you must regenerate the vocabulary** - technically you
 just need a vocab file for the new feature, but it's simpler to regenerate it
-all. See the [demo section](demo/demo.md#collect-trace-and-generate-vocab)
+all. See the [demo section](inlining-demo/demo.md#collect-trace-and-generate-vocab)
 
 **Note:** You only need to regenerate the vocabulary if the feature is going
 to be normalized by a preprocessing layer for your model. If your feature does
@@ -36,7 +36,7 @@ to regenerate the vocabulary and that your feature is added to the list
 returned by `get_nonnormalized_features()` in `config.py`. In either case,
 it is still quite simple and fast to just call the vocab generation again.
 
-After that, retrain from [scratch](demo/demo.md#train-a-new-model).
+After that, retrain from [scratch](inlining-demo/demo.md#train-a-new-model).
 
 ## Notes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,8 +2,8 @@
 
 We'd love to accept your patches and contributions to this project. A good
 starting step to get familiar with the project and set up a development
-enviroment as per [demo](docs/demo/demo.md). After running through the demo, a
-good second step is to pick up an open
+enviroment as per the inlining [demo](inlining-demo/demo.md). After running 
+through the demo, a good second step is to pick up an open
 [issue](https://github.com/google/ml-compiler-opt/issues) or create one that you
 would like to work on and submit a patch for. Please make sure that your patch
 adheres to all the guidelines given below.


### PR DESCRIPTION
Should fix #181.

Fixes the demo links that originally pointed to the inlining-for-size demo to the new path for that demo and adds a link to the regalloc demo in the README.