### PR TITLE
Add distributed PPO training.

### DIFF
--- a/compiler_opt/rl/distributed/__init__.py
+++ b/compiler_opt/rl/distributed/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/compiler_opt/rl/distributed/agent.py
+++ b/compiler_opt/rl/distributed/agent.py
@@ -1,0 +1,443 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PPO agent definition and utility functions."""
+
+from typing import Optional, Text, Tuple
+
+from absl import logging
+
+import tensorflow as tf
+
+from tf_agents.agents.ppo import ppo_agent
+from tf_agents.agents.ppo import ppo_utils
+from tf_agents.networks import network
+from tf_agents.trajectories import time_step as ts
+from tf_agents.typing import types
+from tf_agents.utils import common
+from tf_agents.utils import eager_utils
+from tf_agents.utils import nest_utils
+from tf_agents.utils import object_identity
+from tf_agents.utils import value_ops
+
+
+def _normalize_advantages(advantages, axes=(0), variance_epsilon=1e-8):
+  adv_mean, adv_var = tf.nn.moments(x=advantages, axes=axes, keepdims=True)
+  normalized_advantages = ((advantages - adv_mean) /
+                           (tf.sqrt(adv_var) + variance_epsilon))
+  return normalized_advantages
+
+
+class MLGOPPOAgent(ppo_agent.PPOAgent):
+  """A PPO Agent for MLGO training.
+
+  Major differencs between this and ppo_agent.PPOAgent:
+  - Loss aggregation uses reduce_mean instead of common.aggregate_losses which
+    handles aggregation across multiple accelerator cores.
+  - Normalization is done manually as opposed to `tf.nn.batch_normalization`
+    which leads to different results in TPU setups.
+  """
+
+  def __init__(self,
+               time_step_spec: ts.TimeStep,
+               action_spec: types.NestedTensorSpec,
+               optimizer: Optional[types.Optimizer] = None,
+               actor_net: Optional[network.Network] = None,
+               value_net: Optional[network.Network] = None,
+               importance_ratio_clipping: types.Float = 0.2,
+               discount_factor: types.Float = 1.0,
+               entropy_regularization: types.Float = 0.01,
+               value_pred_loss_coef: types.Float = 0.5,
+               gradient_clipping: Optional[types.Float] = 1.0,
+               value_clipping: Optional[types.Float] = None,
+               check_numerics: bool = False,
+               debug_summaries: bool = False,
+               summarize_grads_and_vars: bool = False,
+               train_step_counter: Optional[tf.Variable] = None,
+               aggregate_losses_across_replicas=False,
+               loss_scaling_factor=1.,
+               name: Optional[Text] = 'PPOClipAgent'):
+    """Creates a PPO Agent implementing the clipped probability ratios.
+
+    Args:
+      time_step_spec: A `TimeStep` spec of the expected time_steps.
+      action_spec: A nest of BoundedTensorSpec representing the actions.
+      optimizer: Optimizer to use for the agent.
+      actor_net: A function actor_net(observations, action_spec) that returns
+        tensor of action distribution params for each observation. Takes nested
+        observation and returns nested action.
+      value_net: A function value_net(time_steps) that returns value tensor from
+        neural net predictions for each observation. Takes nested observation
+        and returns batch of value_preds.
+      importance_ratio_clipping: Epsilon in clipped, surrogate PPO objective.
+        For more detail, see explanation at the top of the doc.
+      discount_factor: Discount factor for return computation.
+      entropy_regularization: Coefficient for entropy regularization loss term.
+      value_pred_loss_coef: Multiplier for value prediction loss to balance with
+        policy gradient loss.
+      gradient_clipping: Norm length to clip gradients.  Default: no clipping.
+      value_clipping: Difference between new and old value predictions are
+        clipped to this threshold. Value clipping could be helpful when training
+        very deep networks. Default: no clipping.
+      check_numerics: If true, adds tf.debugging.check_numerics to help find NaN
+        / Inf values. For debugging only.
+      debug_summaries: A bool to gather debug summaries.
+      summarize_grads_and_vars: If true, gradient summaries will be written.
+      train_step_counter: An optional counter to increment every time the train
+        op is run.  Defaults to the global_step.
+      aggregate_losses_across_replicas: only applicable to setups using multiple
+        relicas. Default to aggregating across multiple cores using common.
+        aggregate_losses. If set to `False`, use `reduce_mean` directly, which
+        is faster but may impact learning results.
+      loss_scaling_factor: the multiplier for scaling the loss, oftentimes
+        1/num_replicas_in_sync.
+      name: The name of this agent. All variables in this module will fall under
+        that name. Defaults to the class name.
+
+    Raises:
+      ValueError: If the actor_net is not a DistributionNetwork.
+    """
+    self._loss_scaling_factor = loss_scaling_factor
+    self._use_tpu = bool(tf.config.list_logical_devices('TPU'))
+
+    super().__init__(
+        time_step_spec,
+        action_spec,
+        optimizer,
+        actor_net,
+        value_net,
+        importance_ratio_clipping=importance_ratio_clipping,
+        discount_factor=discount_factor,
+        entropy_regularization=entropy_regularization,
+        value_pred_loss_coef=value_pred_loss_coef,
+        gradient_clipping=gradient_clipping,
+        value_clipping=value_clipping,
+        check_numerics=check_numerics,
+        debug_summaries=debug_summaries,
+        summarize_grads_and_vars=summarize_grads_and_vars,
+        train_step_counter=train_step_counter,
+        name=name,
+        aggregate_losses_across_replicas=aggregate_losses_across_replicas,
+        # Epochs are set through the tf.Data pipeline outside of the agent.
+        num_epochs=1,
+        # Value and advantages are computed as part of the data pipeline, this
+        # is set to False for all setups using minibatching and PPOLearner.
+        compute_value_and_advantage_in_train=False,
+        # Skips GAE, TD lambda returns, rewards and observations normalization.
+        use_gae=False,
+        use_td_lambda_return=False,
+        normalize_rewards=False,
+        normalize_observations=False,
+        update_normalizers_in_train=False,
+        # Skips log probability clipping and L2 losses.
+        log_prob_clipping=0.0,
+        policy_l2_reg=0.,
+        value_function_l2_reg=0.,
+        shared_vars_l2_reg=0.,
+        # Skips parameters used for the adaptive KL loss penalty version of PPO.
+        kl_cutoff_factor=0.0,
+        kl_cutoff_coef=0.0,
+        initial_adaptive_kl_beta=0.0,
+        adaptive_kl_target=0.0,
+        adaptive_kl_tolerance=0.0)
+
+  def compute_return_and_advantage(
+      self, next_time_steps: ts.TimeStep,
+      value_preds: types.Tensor) -> Tuple[types.Tensor, types.Tensor]:
+    """Compute the Monte Carlo return and advantage.
+
+    Args:
+      next_time_steps: batched tensor of TimeStep tuples after action is taken.
+      value_preds: Batched value prediction tensor. Should have one more entry
+        in time index than time_steps, with the final value corresponding to the
+        value prediction of the final state.
+
+    Returns:
+      tuple of (return, advantage), both are batched tensors.
+    """
+    discounts = next_time_steps.discount * tf.constant(
+        self._discount_factor, dtype=tf.float32)
+
+    rewards = next_time_steps.reward
+    # TODO(b/202226773): Move debugging to helper function for clarity.
+    if self._debug_summaries:
+      # Summarize rewards before they get normalized below.
+      # TODO(b/171573175): remove the condition once histograms are
+      # supported on TPUs.
+      if not self._use_tpu:
+        tf.compat.v2.summary.histogram(
+            name='rewards', data=rewards, step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='rewards_mean',
+          data=tf.reduce_mean(rewards),
+          step=self.train_step_counter)
+
+    # Normalize rewards if self._reward_normalizer is defined.
+    if self._reward_normalizer:
+      rewards = self._reward_normalizer.normalize(
+          rewards, center_mean=False, clip_value=self._reward_norm_clipping)
+      if self._debug_summaries:
+        # TODO(b/171573175): remove the condition once histograms are
+        # supported on TPUs.
+        if not self._use_tpu:
+          tf.compat.v2.summary.histogram(
+              name='rewards_normalized',
+              data=rewards,
+              step=self.train_step_counter)
+        tf.compat.v2.summary.scalar(
+            name='rewards_normalized_mean',
+            data=tf.reduce_mean(rewards),
+            step=self.train_step_counter)
+
+    # Make discount 0.0 at end of each episode to restart cumulative sum
+    #   end of each episode.
+    episode_mask = common.get_episode_mask(next_time_steps)
+    discounts *= episode_mask
+
+    # Compute Monte Carlo returns. Data from incomplete trajectories, not
+    #   containing the end of an episode will also be used, with a bootstrapped
+    #   estimation from the last value.
+    # Note that when a trajectory driver is used, then the final step is
+    #   terminal, the bootstrapped estimation will not be used, as it will be
+    #   multiplied by zero (the discount on the last step).
+    # TODO(b/202055908): Use -1 instead to bootstrap from the last step, once
+    # we verify that it has no negative impact on learning.
+    final_value_bootstrapped = value_preds[:, -2]
+    returns = value_ops.discounted_return(
+        rewards,
+        discounts,
+        time_major=False,
+        final_value=final_value_bootstrapped)
+    # TODO(b/171573175): remove the condition once histograms are
+    # supported on TPUs.
+    if self._debug_summaries and not self._use_tpu:
+      tf.compat.v2.summary.histogram(
+          name='returns', data=returns, step=self.train_step_counter)
+
+    # Compute advantages.
+    advantages = self.compute_advantages(rewards, returns, discounts,
+                                         value_preds)
+
+    # TODO(b/171573175): remove the condition once historgrams are
+    # supported on TPUs.
+    if self._debug_summaries and not self._use_tpu:
+      tf.compat.v2.summary.histogram(
+          name='advantages', data=advantages, step=self.train_step_counter)
+
+    # Return TD-Lambda returns if both use_td_lambda_return and use_gae.
+    if self._use_td_lambda_return:
+      if not self._use_gae:
+        logging.warning('use_td_lambda_return was True, but use_gae was '
+                        'False. Using Monte Carlo return.')
+      else:
+        returns = tf.add(
+            advantages, value_preds[:, :-1], name='td_lambda_returns')
+
+    return returns, advantages
+
+  def _train(self, experience, weights):
+    experience = self._as_trajectory(experience)
+
+    if self._compute_value_and_advantage_in_train:
+      processed_experience = self._preprocess(experience)
+    else:
+      processed_experience = experience
+
+    def squeeze_time_dim(t):
+      return tf.squeeze(t, axis=[1])
+
+    processed_experience = tf.nest.map_structure(squeeze_time_dim,
+                                                 processed_experience)
+
+    valid_mask = ppo_utils.make_trajectory_mask(processed_experience)
+
+    masked_weights = valid_mask
+    if weights is not None:
+      masked_weights *= weights
+
+    # Reconstruct per-timestep policy distribution from stored distribution
+    #   parameters.
+    old_action_distribution_parameters = (
+        processed_experience.policy_info['dist_params'])
+
+    old_actions_distribution = (
+        ppo_utils.distribution_from_spec(
+            self._action_distribution_spec,
+            old_action_distribution_parameters,
+            legacy_distribution_network=isinstance(
+                self._actor_net, network.DistributionNetwork)))
+
+    # Compute log probability of actions taken during data collection, using the
+    #   collect policy distribution.
+    old_act_log_probs = common.log_probability(old_actions_distribution,
+                                               processed_experience.action,
+                                               self._action_spec)
+
+    # TODO(b/171573175): remove the condition once histograms are
+    # supported on TPUs.
+    if self._debug_summaries and not self._use_tpu:
+      actions_list = tf.nest.flatten(processed_experience.action)
+      show_action_index = len(actions_list) != 1
+      for i, single_action in enumerate(actions_list):
+        action_name = (f'actions_{i}' if show_action_index else 'actions')
+        tf.compat.v2.summary.histogram(
+            name=action_name, data=single_action, step=self.train_step_counter)
+
+    time_steps = ts.TimeStep(
+        step_type=processed_experience.step_type,
+        reward=processed_experience.reward,
+        discount=processed_experience.discount,
+        observation=processed_experience.observation)
+
+    actions = processed_experience.action
+    returns = processed_experience.policy_info['return']
+    advantages = processed_experience.policy_info['advantage']
+
+    normalized_advantages = _normalize_advantages(
+        advantages, variance_epsilon=1e-8)
+
+    # TODO(b/171573175): remove the condition once histograms are
+    # supported on TPUs.
+    if self._debug_summaries and not self._use_tpu:
+      tf.compat.v2.summary.histogram(
+          name='advantages_normalized',
+          data=normalized_advantages,
+          step=self.train_step_counter)
+    old_value_predictions = processed_experience.policy_info['value_prediction']
+
+    batch_size = nest_utils.get_outer_shape(time_steps, self._time_step_spec)[0]
+
+    loss_info = None  # TODO(b/123627451): Remove.
+    variables_to_train = list(
+        object_identity.ObjectIdentitySet(self._actor_net.trainable_weights +
+                                          self._value_net.trainable_weights))
+    # Sort to ensure tensors on different processes end up in same order.
+    variables_to_train = sorted(variables_to_train, key=lambda x: x.name)
+
+    with tf.GradientTape(watch_accessed_variables=False) as tape:
+      tape.watch(variables_to_train)
+      loss_info = self.get_loss(
+          time_steps,
+          actions,
+          old_act_log_probs,
+          returns,
+          normalized_advantages,
+          old_action_distribution_parameters,
+          masked_weights,
+          self.train_step_counter,
+          self._debug_summaries,
+          old_value_predictions=old_value_predictions,
+          training=True)
+
+      # Scales the loss, often set to 1/num_replicas, which results in using
+      # the average loss across all of the replicas for backprop.
+      scaled_loss = loss_info.loss * self._loss_scaling_factor
+
+    grads = tape.gradient(scaled_loss, variables_to_train)
+    if self._gradient_clipping > 0:
+      grads, _ = tf.clip_by_global_norm(grads, self._gradient_clipping)
+
+    self._grad_norm = tf.linalg.global_norm(grads)
+
+    # Tuple is used for py3, where zip is a generator producing values once.
+    grads_and_vars = tuple(zip(grads, variables_to_train))
+
+    # If summarize_gradients, create functions for summarizing both
+    # gradients and variables.
+    if self._summarize_grads_and_vars and self._debug_summaries:
+      eager_utils.add_gradients_summaries(grads_and_vars,
+                                          self.train_step_counter)
+      eager_utils.add_variables_summaries(grads_and_vars,
+                                          self.train_step_counter)
+
+    self._optimizer.apply_gradients(grads_and_vars)
+    self.train_step_counter.assign_add(1)
+
+    # TODO(b/1613650790: Move this logic to PPOKLPenaltyAgent.
+    if self._initial_adaptive_kl_beta > 0:
+      # After update epochs, update adaptive kl beta, then update observation
+      #   normalizer and reward normalizer.
+      policy_state = self._collect_policy.get_initial_state(batch_size)
+      # Compute the mean kl from previous action distribution.
+      kl_divergence = self._kl_divergence(
+          time_steps, old_action_distribution_parameters,
+          self._collect_policy.distribution(time_steps, policy_state).action)
+      self.update_adaptive_kl_beta(kl_divergence)
+
+    if self.update_normalizers_in_train:
+      self.update_observation_normalizer(time_steps.observation)
+      self.update_reward_normalizer(processed_experience.reward)
+
+    loss_info = tf.nest.map_structure(tf.identity, loss_info)
+
+    with tf.name_scope('Losses/'):
+      tf.compat.v2.summary.scalar(
+          name='policy_gradient_loss',
+          data=loss_info.extra.policy_gradient_loss,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='value_estimation_loss',
+          data=loss_info.extra.value_estimation_loss,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='l2_regularization_loss',
+          data=loss_info.extra.l2_regularization_loss,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='entropy_regularization_loss',
+          data=loss_info.extra.entropy_regularization_loss,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='kl_penalty_loss',
+          data=loss_info.extra.kl_penalty_loss,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='clip_fraction',
+          data=loss_info.extra.clip_fraction,
+          step=self.train_step_counter)
+      tf.compat.v2.summary.scalar(
+          name='grad_norm', data=self._grad_norm, step=self.train_step_counter)
+
+      total_abs_loss = (
+          tf.abs(loss_info.extra.policy_gradient_loss) +
+          tf.abs(loss_info.extra.value_estimation_loss) +
+          tf.abs(loss_info.extra.entropy_regularization_loss) +
+          tf.abs(loss_info.extra.l2_regularization_loss) +
+          tf.abs(loss_info.extra.kl_penalty_loss))
+
+      tf.compat.v2.summary.scalar(
+          name='total_abs_loss',
+          data=total_abs_loss,
+          step=self.train_step_counter)
+
+    with tf.name_scope('LearningRate/'):
+      tf.compat.v2.summary.scalar(
+          name='learning_rate',
+          data=self._optimizer.learning_rate,
+          step=self.train_step_counter)
+
+    # TODO(b/171573175): remove the condition once histograms are
+    # supported on TPUs.
+    if self._summarize_grads_and_vars and not self._use_tpu:
+      with tf.name_scope('Variables/'):
+        all_vars = (
+            self._actor_net.trainable_weights +
+            self._value_net.trainable_weights)
+        for var in all_vars:
+          tf.compat.v2.summary.histogram(
+              name=var.name.replace(':', '_'),
+              data=var,
+              step=self.train_step_counter)
+
+    return loss_info

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/common.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/common.gin
@@ -4,6 +4,10 @@ import compiler_opt.rl.regalloc.regalloc_network
 
 config_registry.get_configuration.implementation=@configs.RegallocEvictionConfig
 
+problem_config.flags_to_add.add_flags=()
+problem_config.flags_to_delete.delete_flags=('-split-dwarf-file','-split-dwarf-output',)
+problem_config.flags_to_replace.replace_flags={}
+
 launcher_path=None
 clang_path=None
 

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/common.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/common.gin
@@ -1,0 +1,30 @@
+import compiler_opt.rl.constant_value_network
+import compiler_opt.rl.regalloc.config
+import compiler_opt.rl.regalloc.regalloc_network
+
+config_registry.get_configuration.implementation=@configs.RegallocEvictionConfig
+
+launcher_path=None
+clang_path=None
+
+per_replica_batch_size     = 1024
+num_epochs                 = 4
+num_iterations             = 10000
+num_episodes_per_iteration = 2048
+sequence_length            = 128
+
+runners.RegAllocRunner.clang_path=%clang_path
+runners.RegAllocRunner.launcher_path=%launcher_path
+
+# Feature preprocessing
+regalloc.config.get_observation_processing_layer_creator.quantile_file_dir = '/tmp/vocab/'
+regalloc.config.get_observation_processing_layer_creator.with_sqrt = True
+regalloc.config.get_observation_processing_layer_creator.with_z_score_normalization = False
+
+# Policy specification
+create_agent.policy_network = @regalloc_network.RegAllocNetwork
+RegAllocNetwork.fc_layer_params = (80, 40)
+RegAllocNetwork.dropout_layer_params = None
+
+# Value network
+ConstantValueNetwork.constant_output_val = 0

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_collect.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_collect.gin
@@ -1,0 +1,5 @@
+import compiler_opt.rl.distributed.ppo_collect_lib
+
+include 'compiler_opt/rl/distributed/gin_configs/regalloc/common.gin'
+
+run_collect.sequence_length = %sequence_length

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_eval.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_eval.gin
@@ -1,0 +1,3 @@
+import compiler_opt.rl.distributed.ppo_eval_lib
+
+include 'compiler_opt/rl/distributed/gin_configs/regalloc/common.gin'

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_reverb.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_reverb.gin
@@ -1,0 +1,5 @@
+import compiler_opt.rl.distributed.ppo_reverb_server_lib
+
+include 'compiler_opt/rl/distributed/gin_configs/regalloc/common.gin'
+
+run_reverb_server.num_epochs = %num_epochs

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_train.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_train.gin
@@ -1,0 +1,11 @@
+import compiler_opt.rl.distributed.ppo_train_lib
+
+include 'compiler_opt/rl/distributed/gin_configs/regalloc/common.gin'
+
+train.learning_rate = 3e-4
+train.per_replica_batch_size = %per_replica_batch_size
+train.num_epochs = %num_epochs
+train.num_iterations = %num_iterations
+train.num_episodes_per_iteration = %num_episodes_per_iteration
+train.sequence_length = %sequence_length
+train.summary_interval = 1024

--- a/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_train.gin
+++ b/compiler_opt/rl/distributed/gin_configs/regalloc/ppo_train.gin
@@ -2,7 +2,6 @@ import compiler_opt.rl.distributed.ppo_train_lib
 
 include 'compiler_opt/rl/distributed/gin_configs/regalloc/common.gin'
 
-train.learning_rate = 3e-4
 train.per_replica_batch_size = %per_replica_batch_size
 train.num_epochs = %num_epochs
 train.num_iterations = %num_iterations

--- a/compiler_opt/rl/distributed/learner.py
+++ b/compiler_opt/rl/distributed/learner.py
@@ -1,0 +1,263 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility to create MLGO policy learner."""
+
+from typing import Callable, List, Optional, Text, Tuple
+
+from absl import logging
+
+import tensorflow as tf
+from tf_agents.agents.ppo import ppo_agent
+from tf_agents.train import interval_trigger
+from tf_agents.train import learner
+from tf_agents.typing import types
+
+# A function which processes a tuple of a nested tensor representing a TF-Agent
+# Trajectory and Reverb SampleInfo.
+_SequenceParamsType = Tuple[types.NestedTensor, types.ReverbSampleInfo]
+_SequenceFnType = Callable[[_SequenceParamsType], _SequenceParamsType]
+
+
+class MLGOPPOLearner(object):
+  """Manages all the learning details needed.
+
+  These include:
+    * Using distribution strategies correctly
+    * Summaries
+    * Checkpoints
+    * Minimizing entering/exiting TF context:
+        Especially in the case of TPUs scheduling a single TPU program to
+        perform multiple train steps is critical for performance.
+    * Generalizes the train call to be done correctly across CPU, GPU, or TPU
+      executions managed by DistributionStrategies. This uses `strategy.run` and
+      then makes sure to do a reduce operation over the `LossInfo` returned by
+      the agent.
+  """
+
+  def __init__(self,
+               root_dir: Text,
+               train_step: tf.Variable,
+               model_id: tf.Variable,
+               agent: ppo_agent.PPOAgent,
+               experience_dataset_fn: Callable[[], tf.data.Dataset],
+               sequence_length: int,
+               num_episodes_per_iteration: int,
+               minibatch_size: int,
+               shuffle_buffer_size: int,
+               num_epochs: int = 1,
+               triggers: Optional[List[
+                   interval_trigger.IntervalTrigger]] = None,
+               checkpoint_interval: int = 100000,
+               summary_interval: int = 1000,
+               strategy: Optional[tf.distribute.Strategy] = None,
+               per_sequence_fn: Optional[_SequenceFnType] = None,
+               allow_variable_length_episodes: bool = False) -> None:
+    """Initializes a MLGOPPOLearner instance.
+
+    Args:
+      root_dir: Main directory path where checkpoints, saved_models, and
+        summaries will be written to.
+      train_step: a scalar tf.int64 `tf.Variable` which will keep track of the
+        number of train steps. This is used for artifacts created like
+        summaries, or outputs in the root_dir.
+      model_id: a scalar tf.int64 `tf.Variable` which will keep track of the
+        number of learner iterations / policy updates.
+      agent: `ppo_agent.PPOAgent` instance to train with. Note that
+        update_normalizers_in_train should be set to `False`, otherwise a
+        ValueError will be raised. We do not update normalizers in the agent
+        again because we already update it in the learner. When mini batching is
+        enabled, compute_value_and_advantage_in_train should be set to False,
+        and preprocessing should be done as part of the data pipeline as part of
+        `replay_buffer.as_dataset`.
+      experience_dataset_fn: a function that will create an instance of a
+        tf.data.Dataset used to sample experience for training. Each element in
+        the dataset is a (Trajectory, SampleInfo) pair.
+      sequence_length: Fixed sequence length for elements in the dataset. Used
+        for calculating how many iterations of minibatches to use for training.
+      num_episodes_per_iteration: The number of episodes to sample for training.
+        If fewer than this amount of episodes exists in the dataset, the learner
+        will wait for more data to be added, or until the reverb timeout is
+        reached.
+      minibatch_size: The minibatch size. The dataset used for training is
+        shaped `[minibatch_size, 1, ...]`. If None, full sequences will be fed
+        into the agent. Please set this parameter to None for RNN networks which
+        requires full sequences.
+      shuffle_buffer_size: The buffer size for shuffling the trajectories before
+        splitting them into mini batches. Only required when mini batch learning
+        is enabled (minibatch_size is set). Otherwise it is ignored. Commonly
+        set to a number 1-3x the episode length of your environment.
+      num_epochs: The number of iterations to go through the same sequences.
+      triggers: List of callables of the form `trigger(train_step)`. After every
+        `run` call every trigger is called with the current `train_step` value
+        as an np scalar.
+      checkpoint_interval: Number of train steps in between checkpoints. Note
+        these are placed into triggers and so a check to generate a checkpoint
+        only occurs after every `run` call. Set to -1 to disable (this is not
+        recommended, because it means that if the pipeline gets preempted, all
+        previous progress is lost). This only takes care of the checkpointing
+        the training process.  Policies must be explicitly exported through
+        triggers.
+      summary_interval: Number of train steps in between summaries. Note these
+        are placed into triggers and so a check to generate a checkpoint only
+        occurs after every `run` call.
+      strategy: (Optional) `tf.distribute.Strategy` to use during training.
+      per_sequence_fn: (Optional): sequence-wise preprecessing, pass in agent.
+        preprocess for advantage calculation. This operation happens after
+        take() and before rebatching.
+      allow_variable_length_episodes: Whether to support variable length
+        episodes for training.
+
+    Raises:
+      ValueError: agent._compute_value_and_advantage_in_train is set to `True`.
+        preprocessing must be done as part of the data pipeline when mini
+        batching is enabled.
+    """
+
+    self._strategy = strategy or tf.distribute.get_strategy()
+    self._agent = agent
+    self._minibatch_size = minibatch_size
+    self._shuffle_buffer_size = shuffle_buffer_size
+    self._num_epochs = num_epochs
+    self._experience_dataset_fn = experience_dataset_fn
+    self._num_episodes_per_iteration = num_episodes_per_iteration
+    # Tracks the number of times learner.run() has been called.
+    # This is used for filtering out data generated by older models to ensure
+    # the on policyness of the algorithm.
+    self._model_id = model_id
+    self._sequence_length = sequence_length
+    self._per_sequence_fn = per_sequence_fn
+
+    self._generic_learner = learner.Learner(
+        root_dir,
+        train_step,
+        agent,
+        after_train_strategy_step_fn=None,
+        triggers=triggers,
+        checkpoint_interval=checkpoint_interval,
+        summary_interval=summary_interval,
+        use_kwargs_in_agent_train=False,
+        strategy=self._strategy)
+
+    self.num_replicas = self._strategy.num_replicas_in_sync
+    self._allow_variable_length_episodes = allow_variable_length_episodes
+    self._num_samples = self._num_episodes_per_iteration * self._sequence_length
+    self._create_datasets()
+    self._steps_per_iter = self._get_train_steps_per_iteration()
+
+    logging.info('[Learner] Replicas for training: %d', self.num_replicas)
+    logging.info('[Learner] Samples per iteration: %d', self._num_samples)
+    logging.info('[Learner] Train steps per iteration: %d',
+                 self._steps_per_iter)
+
+  def _create_datasets(self):
+    """Create the training dataset and iterator."""
+
+    def _filter_invalid_episodes(sample):
+      sample_info = sample.info
+      data_model_id = tf.cast(
+          tf.reduce_min(sample_info.priority), dtype=tf.int64)
+
+      if self._allow_variable_length_episodes:
+        # Filter off policy samples.
+        return tf.math.equal(self._model_id, data_model_id)
+      else:
+        # Filter infeasible placements with shorter episode lengths than
+        # expected along with off policy samples.
+        data = sample.data
+        return tf.math.logical_and(
+            tf.math.equal(tf.size(data.discount), self._sequence_length),
+            tf.math.equal(self._model_id, data_model_id))
+
+    def make_dataset(_):
+      # `experience_dataset_fn` returns a tf.Dataset. Each item is a (Trajectory
+      # , SampleInfo) tuple, and the Trajectory represents one single episode
+      # of a fixed sequence length. The Trajectory dimensions are [1, T, ...].
+      train_dataset = self._experience_dataset_fn()
+      train_dataset = train_dataset.filter(_filter_invalid_episodes)
+      if self._per_sequence_fn:
+        train_dataset = train_dataset.map(
+            self._per_sequence_fn,
+            num_parallel_calls=tf.data.AUTOTUNE,
+            deterministic=False)
+
+      # We unbatch the dataset shaped [B, T, ...] to a new dataset that
+      # contains individual elements.
+      # Note that we unbatch across the time dimension, which could result
+      # in mini batches that contain subsets from more than one sequences.
+      # PPO agent can handle mini batches across episode boundaries.
+      train_dataset = train_dataset.unbatch()
+      train_dataset = train_dataset.batch(1, drop_remainder=True)
+      train_dataset = train_dataset.shuffle(self._shuffle_buffer_size)
+      #train_dataset = train_dataset.take(self._num_samples)
+      #train_dataset = train_dataset.cache()
+      train_dataset = train_dataset.repeat(self._num_epochs)
+      train_dataset = train_dataset.batch(
+          self._minibatch_size, drop_remainder=True)
+      #train_dataset = train_dataset.repeat()
+
+      options = tf.data.Options()
+      options.deterministic = False
+      options.experimental_optimization.parallel_batch = True
+      train_dataset = train_dataset.with_options(options)
+
+      return train_dataset
+
+    with self._strategy.scope():
+
+      if self._strategy.num_replicas_in_sync > 1:
+        self._train_dataset = (
+            self._strategy.distribute_datasets_from_function(make_dataset))
+      else:
+        self._train_dataset = make_dataset(0)
+      self._train_iterator = iter(self._train_dataset)
+
+  def _get_train_steps_per_iteration(self):
+    """Number of train steps each time learner.run() is called."""
+
+    # We exhaust all num_episodes_per_iteration taken from Reverb in this setup.
+    # Here we assume that there's only 1 episode per batch, and each episode is
+    # of the fixed sequence length.
+    num_mini_batches = int(self._num_samples * self._num_epochs /
+                           self._minibatch_size)
+    train_steps = int(num_mini_batches / self.num_replicas)
+    return train_steps
+
+  def wait_for_data(self):
+    """Blocking call on dataset."""
+    traj, sample_info = next(self._train_iterator)
+    del traj
+    del sample_info
+
+  def run(self):
+    """Train `num_episodes_per_iteration` repeating for `num_epochs`.
+
+    Returns:
+      The total loss computed before running the final step.
+    """
+    loss_info = self._generic_learner.run(self._steps_per_iter,
+                                          self._train_iterator)
+    self._model_id.assign_add(1)
+    self._create_datasets()
+    return loss_info
+
+  @property
+  def train_step_numpy(self):
+    """The current train_step.
+
+    Returns:
+      The current `train_step`. Note this will return a scalar numpy array which
+      holds the `train_step` value when this was called.
+    """
+    return self._generic_learner.train_step_numpy

--- a/compiler_opt/rl/distributed/ppo_collect.py
+++ b/compiler_opt/rl/distributed/ppo_collect.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Collect experiences for PPO training"""
+
+import gin
+import functools
+
+from absl import app
+from absl import flags
+from absl import logging
+
+from tf_agents.system import system_multiprocessing as multiprocessing
+
+from compiler_opt.rl.distributed import ppo_collect_lib
+from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPoolManager
+
+flags.DEFINE_string('root_dir', None,
+                    'Root directory for writing logs/summaries/checkpoints.')
+flags.DEFINE_string('corpus_path', None, 'Path to the training corpus.')
+flags.DEFINE_string('replay_buffer_server_address', None,
+                    'Replay buffer server address.')
+flags.DEFINE_string('variable_container_server_address', None,
+                    'Variable container server address.')
+flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
+flags.DEFINE_multi_string('gin_bindings', None, 'Gin binding parameters.')
+flags.DEFINE_integer(
+    'num_workers', None,
+    'Number of parallel data collection workers. `None` for max available')
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+  logging.set_verbosity(logging.INFO)
+
+  gin.parse_config_files_and_bindings(FLAGS.gin_file, FLAGS.gin_bindings)
+  logging.info(gin.config_str())
+
+  ppo_collect_lib.run_collect(
+      root_dir=FLAGS.root_dir,
+      corpus_path=FLAGS.corpus_path,
+      replay_buffer_server_address=FLAGS.replay_buffer_server_address,
+      variable_container_server_address=FLAGS.variable_container_server_address,
+      num_workers=FLAGS.num_workers,
+      worker_manager_class=LocalWorkerPoolManager)
+
+
+if __name__ == '__main__':
+  flags.mark_flags_as_required([
+      'root_dir', 'corpus_path', 'replay_buffer_server_address',
+      'variable_container_server_address'
+  ])
+  multiprocessing.handle_main(functools.partial(app.run, main))

--- a/compiler_opt/rl/distributed/ppo_collect_lib.py
+++ b/compiler_opt/rl/distributed/ppo_collect_lib.py
@@ -1,0 +1,230 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Collect experiences for PPO training"""
+
+import collections
+import os
+from typing import List, Optional
+import tempfile
+import functools
+
+from absl import logging
+
+import gin
+import reverb
+
+import tensorflow as tf
+import tensorflow.compat.v1 as tf_v1
+from tf_agents.experimental.distributed import reverb_variable_container
+from tf_agents.replay_buffers import reverb_utils
+
+from tf_agents.train import learner
+from tf_agents.train.utils import train_utils
+from tf_agents.utils import common
+
+from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
+from compiler_opt.rl import local_data_collector
+from compiler_opt.rl import corpus
+from compiler_opt.rl import data_reader
+from compiler_opt.rl import policy_saver
+from compiler_opt.rl import registry
+from compiler_opt.rl import agent_creators
+from compiler_opt.rl import constant
+from compiler_opt.rl import compilation_runner
+
+
+def _get_policy_bytes(agent):
+  """Recover the collect_policy bytes from a TF agent"""
+  policy_key = 'collect'
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    saver = policy_saver.PolicySaver(policy_dict={
+        policy_key: agent.collect_policy,
+    })
+    saver.save(tmpdirname)
+    return policy_saver.Policy.from_filesystem(
+        os.path.join(tmpdirname, policy_key))
+
+
+class ReverbComplicationObserver(compilation_runner.CompilationResultObserver):
+  """Observer which sends compilation results to reverb"""
+
+  def __init__(self,
+               time_step_spec,
+               action_spec,
+               replay_buffer_server_address: str,
+               sequence_length: int,
+               initial_priority: float = 0.0):
+    self._observer = reverb_utils.ReverbTrajectorySequenceObserver(
+        reverb.Client(replay_buffer_server_address),
+        table_name=[
+            'training_table',
+        ],
+        sequence_length=sequence_length,
+        stride_length=sequence_length,
+        priority=initial_priority)
+
+    self._parser = data_reader.create_flat_sequence_example_dataset_fn(
+        agent_name=constant.AgentName.PPO_DISTRIBUTED,
+        time_step_spec=time_step_spec,
+        action_spec=action_spec)
+
+  def _is_actionable_result(
+      self, result: compilation_runner.CompilationResult) -> bool:
+    """Predicate which checks if the result contains valid experiences"""
+    return bool(result.keys)
+
+  def observe(self, result: compilation_runner.CompilationResult) -> None:
+    """Observe the compilation result.
+
+    Specifically, parses the serialized sequence examples and sends each
+    experience to reverb.
+    """
+    assert result.model_id is not None
+    if self._is_actionable_result(result):
+      # pylint: disable=protected-access
+      self._observer._priority = result.model_id
+      parsed = self._parser(result.serialized_sequence_examples)
+      for experience in parsed:
+        self._observer(experience)
+
+
+def collect(corpus_path: str, replay_buffer_server_address: str,
+            variable_container_server_address: str, num_workers: Optional[int],
+            worker_manager_class, sequence_length: int) -> None:
+  """Collects experience using a policy updated after every episode.
+
+  Args:
+    corpus_path: path to the corpus to collect from.
+    replay_buffer_server_address: address of the replay buffer in reverb.
+    variable_container_server_address: address of the variable container in
+      reverb.
+    num_workers: number of workers in the pool to collect from.
+    worker_manager_class: type of the worker manager to spawn the pool with.
+    sequence_length: sequence length of the examples.
+  """
+
+  # Set up the problem & initialize the agent
+  logging.info('Initializing the distributed PPO agent')
+  problem_config = registry.get_configuration()
+  time_step_spec, action_spec = problem_config.get_signature_spec()
+  agent = agent_creators.create_agent(
+      constant.AgentName.PPO_DISTRIBUTED, time_step_spec, action_spec,
+      problem_config.get_preprocessing_layer_creator())
+
+  # Initialize the reverb variable container
+  logging.info('Connecting to the reverb server')
+  train_step = tf_v1.train.get_or_create_global_step()
+  model_id = common.create_variable('model_id')
+  variables = {
+      reverb_variable_container.POLICY_KEY: agent.collect_policy.variables(),
+      reverb_variable_container.TRAIN_STEP_KEY: train_step,
+      'model_id': model_id
+  }
+  variable_container = reverb_variable_container.ReverbVariableContainer(
+      variable_container_server_address,
+      table_names=[reverb_variable_container.DEFAULT_TABLE])
+  variable_container.update(variables)
+
+  create_observer_fns = [
+      functools.partial(
+          ReverbComplicationObserver,
+          time_step_spec=time_step_spec,
+          action_spec=action_spec,
+          replay_buffer_server_address=replay_buffer_server_address,
+          sequence_length=sequence_length)
+  ]
+
+  # Setup the corpus
+  logging.info('Constructing tf.data pipeline and module corpus')
+  dataset_fn = data_reader.create_flat_sequence_example_dataset_fn(
+      agent_name=constant.AgentName.PPO_DISTRIBUTED,
+      time_step_spec=time_step_spec,
+      action_spec=action_spec)
+
+  def sequence_example_iterator_fn(seq_ex: List[str]):
+    return iter(dataset_fn(seq_ex).prefetch(tf.data.AUTOTUNE))
+
+  cps = corpus.Corpus(
+      data_path=corpus_path,
+      additional_flags=problem_config.flags_to_add(),
+      delete_flags=problem_config.flags_to_delete(),
+      replace_flags=problem_config.flags_to_replace())
+
+  # Run the experience collection loop.
+  logging.info('Constructing the worker pool')
+  with worker_manager_class(
+      worker_class=problem_config.get_runner_type(),
+      count=num_workers,
+      moving_average_decay_rate=1,
+      create_observer_fns=create_observer_fns) as worker_pool:
+
+    data_collector = local_data_collector.LocalDataCollector(
+        cps=cps,
+        num_modules=num_workers * 128 if num_workers else 512,
+        worker_pool=worker_pool,
+        parser=sequence_example_iterator_fn,
+        reward_stat_map=collections.defaultdict(lambda: None),
+        best_trajectory_repo=None)
+
+    logging.info('Starting collection loop')
+    while True:
+      logging.info('Collecting with model_id: %d at step %d',
+                   model_id.read_value(), train_step.numpy())
+      # Collect experiences which will be sent to reverb by each worker
+      dataset_iter, monitor_dict = data_collector.collect_data(
+          policy=_get_policy_bytes(agent), model_id=model_id.numpy())
+      del dataset_iter
+      del monitor_dict
+      # Fetch updated policy variables
+      variable_container.update(variables)
+
+
+@gin.configurable
+def run_collect(root_dir: str, corpus_path: str,
+                replay_buffer_server_address: str,
+                variable_container_server_address: str,
+                num_workers: Optional[int], worker_manager_class,
+                sequence_length: int):
+  """Collects experience using a policy updated after every episode.
+
+  Waits for a policy to be saved in root_dir before beginning collection.
+
+  Args:
+    root_dir: Directory where the trainer will save policies.
+    corpus_path: path to the corpus to collect from.
+    replay_buffer_server_address: address of the replay buffer in reverb.
+    variable_container_server_address: address of the variable container in
+      reverb.
+    num_workers: number of workers in the pool to collect from.
+    worker_manager_class: type of the worker manager to spawn the pool with.
+    sequence_length: sequence length of the examples.
+  """
+  # Wait for the collect policy to become available, as this signifies the
+  # trainer has come online
+  collect_policy_dir = os.path.join(root_dir, learner.POLICY_SAVED_MODEL_DIR,
+                                    learner.COLLECT_POLICY_SAVED_MODEL_DIR)
+  collect_policy = train_utils.wait_for_policy(
+      collect_policy_dir, load_specs_from_pbtxt=True)
+
+  # But we don't need it, because we will load parameters from the reverb server
+  del collect_policy
+
+  collect(
+      corpus_path=corpus_path,
+      replay_buffer_server_address=replay_buffer_server_address,
+      variable_container_server_address=variable_container_server_address,
+      num_workers=num_workers,
+      worker_manager_class=worker_manager_class,
+      sequence_length=sequence_length)

--- a/compiler_opt/rl/distributed/ppo_collect_lib.py
+++ b/compiler_opt/rl/distributed/ppo_collect_lib.py
@@ -33,6 +33,7 @@ from tf_agents.replay_buffers import reverb_utils
 from tf_agents.train import learner
 from tf_agents.train.utils import train_utils
 from tf_agents.utils import common
+from tf_agents.trajectories import trajectory
 
 from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
 from compiler_opt.rl import local_data_collector

--- a/compiler_opt/rl/distributed/ppo_collect_lib.py
+++ b/compiler_opt/rl/distributed/ppo_collect_lib.py
@@ -57,6 +57,10 @@ def _get_policy_bytes(agent):
         os.path.join(tmpdirname, policy_key))
 
 
+def _add_value_prediction(traj: trajectory.Trajectory):
+  traj.policy_info['value_prediction'] = tf.constant(0.0, dtype=tf.float32)
+
+
 class ReverbCompilationObserver(compilation_runner.CompilationResultObserver):
   """Observer which sends compilation results to reverb"""
 
@@ -97,6 +101,7 @@ class ReverbCompilationObserver(compilation_runner.CompilationResultObserver):
       self._observer._priority = result.model_id
       parsed = self._parser(result.serialized_sequence_examples)
       for experience in parsed:
+        _add_value_prediction(experience)
         self._observer(experience)
 
 

--- a/compiler_opt/rl/distributed/ppo_collect_lib.py
+++ b/compiler_opt/rl/distributed/ppo_collect_lib.py
@@ -57,7 +57,7 @@ def _get_policy_bytes(agent):
         os.path.join(tmpdirname, policy_key))
 
 
-class ReverbComplicationObserver(compilation_runner.CompilationResultObserver):
+class ReverbCompilationObserver(compilation_runner.CompilationResultObserver):
   """Observer which sends compilation results to reverb"""
 
   def __init__(self,
@@ -139,7 +139,7 @@ def collect(corpus_path: str, replay_buffer_server_address: str,
 
   create_observer_fns = [
       functools.partial(
-          ReverbComplicationObserver,
+          ReverbCompilationObserver,
           time_step_spec=time_step_spec,
           action_spec=action_spec,
           replay_buffer_server_address=replay_buffer_server_address,

--- a/compiler_opt/rl/distributed/ppo_eval.py
+++ b/compiler_opt/rl/distributed/ppo_eval.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Evaluate the current policy stored in reverb"""
+
+import functools
+
+import gin
+
+from absl import app
+from absl import flags
+from absl import logging
+
+from tf_agents.system import system_multiprocessing as multiprocessing
+
+from compiler_opt.rl.distributed import ppo_eval_lib
+from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPoolManager
+
+flags.DEFINE_string('root_dir', None,
+                    'Root directory for writing logs/summaries/checkpoints.')
+flags.DEFINE_string('corpus_path', None, 'Path to the training corpus.')
+flags.DEFINE_string('variable_container_server_address', None,
+                    'Variable container server address.')
+flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
+flags.DEFINE_multi_string('gin_bindings', None, 'Gin binding parameters.')
+flags.DEFINE_integer(
+    'num_workers', None,
+    'Number of parallel data collection workers. `None` for max available')
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+  logging.set_verbosity(logging.INFO)
+
+  gin.parse_config_files_and_bindings(FLAGS.gin_file, FLAGS.gin_bindings)
+  logging.info(gin.config_str())
+
+  ppo_eval_lib.run_evaluate(
+      root_dir=FLAGS.root_dir,
+      corpus_path=FLAGS.corpus_path,
+      variable_container_server_address=FLAGS.variable_container_server_address,
+      num_workers=FLAGS.num_workers,
+      worker_manager_class=LocalWorkerPoolManager)
+
+
+if __name__ == '__main__':
+  flags.mark_flags_as_required(
+      ['root_dir', 'variable_container_server_address'])
+  multiprocessing.handle_main(functools.partial(app.run, main))

--- a/compiler_opt/rl/distributed/ppo_eval_lib.py
+++ b/compiler_opt/rl/distributed/ppo_eval_lib.py
@@ -1,0 +1,193 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Evaluate the current policy stored in reverb"""
+
+import tempfile
+import collections
+import os
+import time
+from typing import List, Optional
+
+from absl import logging
+
+import tensorflow as tf
+import tensorflow.compat.v1 as tf_v1
+from tf_agents.experimental.distributed import reverb_variable_container
+from tf_agents.train import learner
+from tf_agents.train.utils import train_utils
+from tf_agents.utils import common
+
+from compiler_opt.rl import data_reader
+from compiler_opt.rl import local_data_collector
+from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
+from compiler_opt.rl import corpus
+from compiler_opt.rl import constant
+from compiler_opt.rl import agent_creators
+from compiler_opt.rl import registry
+from compiler_opt.rl import policy_saver
+from compiler_opt.rl import data_collector
+
+
+def evaluate(root_dir: str, corpus_path: str,
+             variable_container_server_address: str, num_workers: Optional[int],
+             worker_manager_class):
+  """Evaluate a given policy on the given corpus.
+
+  Args:
+    root_dir: path to write tensorboard summaries.
+    corpus_path: path to the corpus to collect from.
+    variable_container_server_address: address of the variable container in
+      reverb.
+    num_workers: number of workers in the pool to collect from.
+    worker_manager_class: type of the worker manager to spawn the pool with.
+  """
+
+  # Set up the problem & initialize the agent
+  logging.info('Initializing the distributed PPO agent')
+  problem_config = registry.get_configuration()
+  time_step_spec, action_spec = problem_config.get_signature_spec()
+  agent = agent_creators.create_agent(
+      constant.AgentName.PPO_DISTRIBUTED, time_step_spec, action_spec,
+      problem_config.get_preprocessing_layer_creator())
+
+  #policy = greedy_policy.GreedyPolicy(agent.policy)
+  policy = agent.collect_policy
+  policy_dict = {'policy': policy}
+
+  # Initialize the reverb variable container
+  logging.info('Connecting to the reverb server')
+  train_step = tf_v1.train.get_or_create_global_step()
+  model_id = common.create_variable('model_id')
+  variables = {
+      reverb_variable_container.POLICY_KEY: policy.variables(),
+      reverb_variable_container.TRAIN_STEP_KEY: train_step,
+      'model_id': model_id
+  }
+  variable_container = reverb_variable_container.ReverbVariableContainer(
+      variable_container_server_address,
+      table_names=[reverb_variable_container.DEFAULT_TABLE])
+  variable_container.update(variables)
+
+  # Setup the corpus
+  logging.info('Constructing tf.data pipeline and module corpus')
+  dataset_fn = data_reader.create_flat_sequence_example_dataset_fn(
+      agent_name=constant.AgentName.PPO_DISTRIBUTED,
+      time_step_spec=time_step_spec,
+      action_spec=action_spec)
+
+  def sequence_example_iterator_fn(seq_ex: List[str]):
+    return iter(dataset_fn(seq_ex).prefetch(tf.data.AUTOTUNE))
+
+  cps = corpus.Corpus(
+      data_path=corpus_path,
+      additional_flags=problem_config.flags_to_add(),
+      delete_flags=problem_config.flags_to_delete(),
+      replace_flags=problem_config.flags_to_replace())
+
+  summary_writer = tf.summary.create_file_writer(
+      root_dir, flush_millis=5 * 1000)
+  summary_writer.set_as_default()
+
+  data_action_mean = tf.keras.metrics.Mean()
+  data_reward_mean = tf.keras.metrics.Mean()
+
+  # Run the experience collection loop.
+  with worker_manager_class(
+      worker_class=problem_config.get_runner_type(),
+      count=num_workers,
+      moving_average_decay_rate=1) as worker_pool:
+    logging.info('constructed pool')
+    collector = local_data_collector.LocalDataCollector(
+        cps=cps,
+        num_modules=128,
+        worker_pool=worker_pool,
+        parser=sequence_example_iterator_fn,
+        reward_stat_map=collections.defaultdict(lambda: None),
+        best_trajectory_repo=None)
+    logging.info('constructed data_collector')
+    last_step = -1
+    rewards = []
+    actions = []
+    while True:
+      with tempfile.TemporaryDirectory() as tmpdirname:
+        saver = policy_saver.PolicySaver(policy_dict=policy_dict)
+        saver.save(tmpdirname)
+        policy_bytes = policy_saver.Policy.from_filesystem(
+            os.path.join(tmpdirname, 'policy'))
+      dataset_iter, monitor_dict = collector.collect_data(
+          policy=policy_bytes, model_id=model_id.numpy())
+      del monitor_dict
+
+      for experience in dataset_iter:
+        is_action = ~experience.is_boundary()
+
+        # pylint: disable=not-callable
+        data_action_mean.update_state(
+            experience.action, sample_weight=is_action)
+        # pylint: disable=not-callable
+        data_reward_mean.update_state(
+            experience.reward, sample_weight=is_action)
+
+        if is_action:
+          rewards.append(experience.reward)
+          actions.append(experience.action)
+
+      if last_step < train_step.numpy():
+        last_step = train_step.numpy()
+        with tf.name_scope('default/'):
+          tf.summary.scalar(
+              name='data_action_mean',
+              # pylint: disable=not-callable
+              data=data_action_mean.result(),
+              step=train_step)
+          tf.summary.scalar(
+              name='data_reward_mean',
+              # pylint: disable=not-callable
+              data=data_reward_mean.result(),
+              step=train_step)
+          tf.summary.scalar(
+              name='num_eval_experiences', data=len(rewards), step=train_step)
+        tf.summary.histogram(name='reward', data=rewards, step=train_step)
+        tf.summary.histogram(name='action', data=actions, step=train_step)
+        with tf.name_scope('reward_distribution/'):
+          reward_dist = data_collector.build_distribution_monitor(rewards)
+          for k, v in reward_dist.items():
+            tf.summary.scalar(name=k, data=v, step=train_step)
+        data_action_mean.reset_state()
+        data_reward_mean.reset_state()
+        rewards = []
+        actions = []
+
+      variable_container.update(variables)
+      logging.info('Evaluating with policy at step: %d', train_step.numpy())
+      time.sleep(20)
+
+
+def run_evaluate(root_dir: str, corpus_path: str,
+                 variable_container_server_address: str,
+                 num_workers: Optional[int], worker_manager_class):
+  """Wait for the collect policy to be ready and run collect job."""
+  # Wait for the collect policy to become available, then load it.
+  policy_dir = os.path.join(root_dir, learner.POLICY_SAVED_MODEL_DIR,
+                            learner.COLLECT_POLICY_SAVED_MODEL_DIR)
+  policy = train_utils.wait_for_policy(policy_dir, load_specs_from_pbtxt=True)
+  del policy
+
+  evaluate(
+      root_dir=root_dir,
+      corpus_path=corpus_path,
+      variable_container_server_address=variable_container_server_address,
+      num_workers=num_workers,
+      worker_manager_class=worker_manager_class)

--- a/compiler_opt/rl/distributed/ppo_reverb_server.py
+++ b/compiler_opt/rl/distributed/ppo_reverb_server.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Main binary to launch a stand alone Reverb RB server."""
+
+from absl import app
+from absl import flags
+from absl import logging
+
+import gin
+
+from compiler_opt.rl.distributed import ppo_reverb_server_lib
+from compiler_opt.rl import registry  # pylint: disable=unused-import
+from compiler_opt.rl import agent_creators  # pylint: disable=unused-import
+
+flags.DEFINE_string('root_dir', None,
+                    'Root directory for writing logs/summaries/checkpoints.')
+flags.DEFINE_integer('replay_buffer_capacity', 1000000,
+                     'Capacity of the replay buffer table.')
+flags.DEFINE_integer('port', None, 'Port to start the server on.')
+flags.DEFINE_multi_string('gin_files', [],
+                          'List of paths to gin configuration files.')
+flags.DEFINE_multi_string(
+    'gin_bindings', [],
+    'Gin bindings to override the values set in the config files.')
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+  logging.set_verbosity(logging.INFO)
+
+  gin.parse_config_files_and_bindings(
+      FLAGS.gin_files, bindings=FLAGS.gin_bindings, skip_unknown=False)
+  logging.info(gin.config_str())
+
+  ppo_reverb_server_lib.run_reverb_server(
+      FLAGS.root_dir,
+      port=FLAGS.port,
+      replay_buffer_capacity=FLAGS.replay_buffer_capacity)
+
+
+if __name__ == '__main__':
+  flags.mark_flags_as_required(['root_dir', 'port'])
+  app.run(main)

--- a/compiler_opt/rl/distributed/ppo_reverb_server_lib.py
+++ b/compiler_opt/rl/distributed/ppo_reverb_server_lib.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Library to launch a stand alone Reverb RB server."""
+
+import os
+
+from absl import logging
+
+import reverb
+import gin
+import tensorflow.compat.v2 as tf
+
+from tf_agents.experimental.distributed import reverb_variable_container
+from tf_agents.specs import tensor_spec
+from tf_agents.train import learner
+from tf_agents.train.utils import train_utils
+from tf_agents.utils import common
+
+
+@gin.configurable
+def run_reverb_server(root_dir: str,
+                      port: int,
+                      replay_buffer_capacity: int,
+                      num_epochs: int = 5):
+  """Start the server after the initial policy becomes available."""
+  # Wait for the collect policy to become available, then load it.
+  collect_policy_dir = os.path.join(root_dir, learner.POLICY_SAVED_MODEL_DIR,
+                                    learner.COLLECT_POLICY_SAVED_MODEL_DIR)
+  collect_policy = train_utils.wait_for_policy(
+      collect_policy_dir, load_specs_from_pbtxt=True)
+
+  # Create the signature for the variable container holding the policy weights.
+  train_step = train_utils.create_train_step()
+  model_id = common.create_variable('model_id')
+  variables = {
+      reverb_variable_container.POLICY_KEY: collect_policy.variables(),
+      reverb_variable_container.TRAIN_STEP_KEY: train_step,
+      'model_id': model_id,
+  }
+  variable_container_signature = tf.nest.map_structure(
+      lambda variable: tf.TensorSpec(variable.shape, dtype=variable.dtype),
+      variables)
+  logging.info('Signature of variables: \n%s', variable_container_signature)
+
+  # Create the signature for the replay buffer holding observed experience.
+  replay_buffer_signature = tensor_spec.from_spec(
+      collect_policy.collect_data_spec)
+  replay_buffer_signature = tensor_spec.add_outer_dim(replay_buffer_signature)
+  logging.info('Signature of experience: \n%s', replay_buffer_signature)
+
+  # Create and start the replay buffer and variable container server.
+  server = reverb.Server(
+      tables=[
+          # The remover does not matter because we clear the table and the end
+          # of each global step. We assume that the table is large enough to
+          # contain the data collected from one step.
+          reverb.Table(
+              name='training_table',
+              sampler=reverb.selectors.Fifo(),
+              remover=reverb.selectors.Fifo(),
+              rate_limiter=reverb.rate_limiters.MinSize(1),
+              max_size=replay_buffer_capacity,
+              max_times_sampled=num_epochs,
+              signature=replay_buffer_signature,
+          ),
+          reverb.Table(
+              name=reverb_variable_container.DEFAULT_TABLE,
+              sampler=reverb.selectors.Fifo(),
+              remover=reverb.selectors.Fifo(),
+              rate_limiter=reverb.rate_limiters.MinSize(1),
+              max_size=1,
+              max_times_sampled=0,
+              signature=variable_container_signature,
+          ),
+      ],
+      port=port)
+  server.wait()

--- a/compiler_opt/rl/distributed/ppo_train.py
+++ b/compiler_opt/rl/distributed/ppo_train.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Binary to train a policy with PPO"""
+
+import functools
+import os
+
+from absl import app
+from absl import flags
+from absl import logging
+
+import gin
+
+from tf_agents.system import system_multiprocessing as multiprocessing
+from tf_agents.train.utils import strategy_utils
+
+from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
+from compiler_opt.rl.distributed import ppo_train_lib
+
+flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+                    'Root directory for writing logs/summaries/checkpoints.')
+flags.DEFINE_string('replay_buffer_server_address', None,
+                    'Replay buffer server address.')
+flags.DEFINE_string('variable_container_server_address', None,
+                    'Variable container server address.')
+flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
+flags.DEFINE_multi_string('gin_bindings', None, 'Gin binding parameters.')
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+  logging.set_verbosity(logging.INFO)
+
+  gin.parse_config_files_and_bindings(FLAGS.gin_file, FLAGS.gin_bindings)
+  logging.info(gin.config_str())
+
+  strategy = strategy_utils.get_strategy(FLAGS.tpu, FLAGS.use_gpu)
+
+  ppo_train_lib.train(
+      FLAGS.root_dir,
+      strategy=strategy,
+      replay_buffer_server_address=FLAGS.replay_buffer_server_address,
+      variable_container_server_address=FLAGS.variable_container_server_address)
+
+
+if __name__ == '__main__':
+  flags.mark_flags_as_required([
+      'root_dir', 'replay_buffer_server_address',
+      'variable_container_server_address'
+  ])
+  multiprocessing.handle_main(functools.partial(app.run, main))

--- a/compiler_opt/rl/distributed/ppo_train_lib.py
+++ b/compiler_opt/rl/distributed/ppo_train_lib.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Library to train a policy with PPO"""
+
+import time
+import os
+
+from absl import logging
+
+import gin
+import reverb
+import tensorflow.compat.v2 as tf
+
+from tf_agents.experimental.distributed import reverb_variable_container
+from tf_agents.replay_buffers import reverb_replay_buffer
+from tf_agents.train import learner as actor_learner
+from tf_agents.train import triggers
+from tf_agents.utils import common
+
+from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
+from compiler_opt.rl import constant
+from compiler_opt.rl import agent_creators
+from compiler_opt.rl import registry
+from compiler_opt.rl.distributed import learner as learner_lib
+
+_SHUFFLE_BUFFER_EPISODE_LEN = 3
+
+
+@gin.configurable
+def train(
+    root_dir: str,
+    strategy: tf.distribute.Strategy,
+    replay_buffer_server_address: str,
+    variable_container_server_address: str,
+    # Training params
+    per_replica_batch_size,
+    num_epochs: int,
+    num_iterations: int,
+    num_episodes_per_iteration: int,
+    sequence_length: int,
+    summary_interval: int):
+  """Trains a PPO agent."""
+  # Get the specs from the environment.
+  problem_config = registry.get_configuration()
+  time_step_spec, action_spec = problem_config.get_signature_spec()
+
+  # Create the agent.
+  with strategy.scope():
+    train_step = tf.compat.v1.train.get_or_create_global_step()
+    agent = agent_creators.create_agent(
+        constant.AgentName.PPO_DISTRIBUTED, time_step_spec, action_spec,
+        problem_config.get_preprocessing_layer_creator())
+    model_id = common.create_variable('model_id')
+    # The model_id should equal to the iteration number.
+    model_id.assign(0)
+    agent.initialize()
+
+  # Create the policy saver which saves the initial model now, then it
+  # periodically checkpoints the policy weigths.
+  saved_model_dir = os.path.join(root_dir, actor_learner.POLICY_SAVED_MODEL_DIR)
+  save_model_trigger = triggers.PolicySavedModelTrigger(
+      saved_model_dir, agent, train_step, interval=1000)
+
+  # Create the variable container.
+  variables = {
+      reverb_variable_container.POLICY_KEY: agent.collect_policy.variables(),
+      reverb_variable_container.TRAIN_STEP_KEY: train_step,
+      'model_id': model_id,
+  }
+  variable_container = reverb_variable_container.ReverbVariableContainer(
+      variable_container_server_address,
+      table_names=[reverb_variable_container.DEFAULT_TABLE])
+  variable_container.push(variables)
+
+  # Create the replay buffer.
+  reverb_replay_train = reverb_replay_buffer.ReverbReplayBuffer(
+      agent.collect_data_spec,
+      sequence_length=sequence_length,
+      table_name='training_table',
+      server_address=replay_buffer_server_address)
+
+  # Initialize the dataset.
+  def experience_dataset_fn():
+    get_dtype = lambda x: x.dtype  # pylint: disable=unnecessary-lambda-assignment
+    get_shape = lambda x: (None,) + x.shape  # pylint: disable=unnecessary-lambda-assignment
+
+    shapes = tf.nest.map_structure(get_shape, agent.collect_data_spec)
+    dtypes = tf.nest.map_structure(get_dtype, agent.collect_data_spec)
+
+    dataset = reverb.TrajectoryDataset(
+        server_address=replay_buffer_server_address,
+        table='training_table',
+        dtypes=dtypes,
+        shapes=shapes,
+        # Menger uses learner_iterations_per_call (256). Using 8 here instead
+        # because we do not need that much data in the buffer (they have to be
+        # filtered out for the next iteration anyways). The rule of thumb is
+        # 2-3x batch_size.
+        max_in_flight_samples_per_worker=8,
+        num_workers_per_iterator=-1,
+        max_samples_per_stream=-1,
+        rate_limiter_timeout_ms=-1,
+    )
+
+    def broadcast_info(info_traj):
+      # Assumes that the first element of traj is shaped
+      # (sequence_length, ...); and we extract this length.
+      info, traj = info_traj
+      first_elem = tf.nest.flatten(traj)[0]
+      length = first_elem.shape[0] or tf.shape(first_elem)[0]
+      info = tf.nest.map_structure(lambda t: tf.repeat(t, [length]), info)
+      return reverb.ReplaySample(info, traj)
+
+    dataset = dataset.map(broadcast_info)
+    return dataset
+
+  # Create the learner.
+  learning_triggers = [
+      save_model_trigger,
+      triggers.StepPerSecondLogTrigger(train_step, interval=100)
+  ]
+
+  def per_sequence_fn(sample):
+    # At this point, each sample data contains a sequence of trajectories.
+    data, info = sample.data, sample.info
+    data = agent.preprocess_sequence(data)
+    return data, info
+
+  learner = learner_lib.MLGOPPOLearner(
+      root_dir,
+      train_step,
+      model_id,
+      agent,
+      experience_dataset_fn,
+      sequence_length,
+      num_episodes_per_iteration=num_episodes_per_iteration,
+      minibatch_size=per_replica_batch_size,
+      shuffle_buffer_size=(_SHUFFLE_BUFFER_EPISODE_LEN * sequence_length),
+      triggers=learning_triggers,
+      summary_interval=summary_interval,
+      strategy=strategy,
+      num_epochs=num_epochs,
+      per_sequence_fn=per_sequence_fn,
+      allow_variable_length_episodes=False)
+
+  # Run the training loop.
+  for i in range(num_iterations):
+    step_val = train_step.numpy()
+    logging.info('Training. Iteration: %d', i)
+    start_time = time.time()
+    learner.wait_for_data()
+    data_wait_time = time.time() - start_time
+    logging.info('Data wait time sec: %s', data_wait_time)
+    loss_info = learner.run()
+    logging.info('Loss info: %s', str(loss_info))
+    num_steps = train_step.numpy() - step_val
+    run_time = time.time() - start_time
+    logging.info('Steps per sec: %s', num_steps / run_time)
+    logging.info('Pushing variables at model_id: %d', model_id.numpy())
+    variable_container.push(variables)
+    logging.info('clearing replay buffer')
+    reverb_replay_train.clear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ charset_normalizer==2.0.4
 cloudpickle==1.6.0
 decorator==5.0.9
 dm-tree==0.1.6
+dm-reverb[tensorflow]==0.9.0
 flatbuffers==2.0
 future==0.18.2
 gast==0.4.0
@@ -43,7 +44,7 @@ tf-estimator-nightly==2.11.0.dev2022082308
 tensorflow-io-gcs-filesystem-nightly==0.26.0.dev20220816191153
 tfp-nightly==0.17.0.dev20220823
 termcolor==1.1.0
-tf-agents-nightly==0.14.0.dev20220823
+tf-agents-nightly==0.15.0.dev20221122
 typing-extensions==4.0.1
 urllib3==1.26.6
 werkzeug==2.0.1


### PR DESCRIPTION
Distributed training works via four processes:

 - ppo_reverb_server.py
 - ppo_train.py
 - ppo_collect.py
 - ppo_eval.py

ppo_train, ppo_collect, and ppo_eval communicate via ppo_reverb_server. The reverb server has two tables of data: one that holds the most recent model weights, and another that holds training data. The train script fetchs examples from reverb, trains, then uploads new model weights to reverb. The collect script fetches the latest model weights, collects training data, then uploads it to reverb. The eval script fetches the latest model weights and writes evaluation data to tensorboard.

Training is distributed, so each of these processes can live on different servers, and you can have as many collect and eval jobs as you need.

Distributed accelerator training is done via tf.distribute.Strategy. The ppo_train_lib.py script accepts a Strategy as input, and the ppo_train.py script uses the default strategy (cpu training). If you have access to TPUs, you can write an alternate ppo_train.py script that passes a TPUStrategy instead. Similarly, if your server has multiple GPUs, you can use a MirroredStrategy to train on all of them.