### PR TITLE
Update Dockerfile to use pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.9
 
 COPY . /ml-compiler-opt
-RUN pip install --no-cache-dir -r /ml-compiler-opt/requirements.txt
+WORKDIR /ml-compiler-opt
+RUN pip install pipenv && pipenv sync --system && pipenv --clear
 
 WORKDIR /ml-compiler-opt/compiler_opt/tools
 ENV PYTHONPATH=/ml-compiler-opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9
 
-COPY . /ml-compiler-opt
 WORKDIR /ml-compiler-opt
+COPY . .
 RUN pip install pipenv && pipenv sync --system && pipenv --clear
 
 WORKDIR /ml-compiler-opt/compiler_opt/tools


### PR DESCRIPTION
This updates the `Dockerfile` to use `pipenv` after #189. Also clears the `pipenv` cache (which also clears the pip cache) afterwards since it's a waste couple hundred MB.

Pinging other people on the Fuchsia team who have made changes here before that Github won't let me add as reviewers for some reason:
@faizan-m @zeroomega 