### PR TITLE
Update development mode Dockerfile to work with pipenv

### DIFF
--- a/experimental/docker/development.Dockerfile
+++ b/experimental/docker/development.Dockerfile
@@ -39,7 +39,8 @@ RUN mkdir /tflite
 WORKDIR /tflite
 COPY buildbot/build_tflite.sh ./
 RUN ./build_tflite.sh
-WORKDIR /
 COPY . /ml-compiler-opt
-RUN python3 -m pip install -r /ml-compiler-opt/requirements-dev.txt
+WORKDIR /ml-compiler-opt
+RUN pip3 install pipenv && pipenv sync --categories "packages dev-packages ci" --system && pipenv --clear
+WORKDIR /
 


### PR DESCRIPTION
This updates the development mode Dockerfile to use `pipenv` for dependency management and also makes sure to clear the cache to save a little bit of storage space.