### PR TITLE
Regenerated lockfile with Python3.8 to increase compatibility

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -560,6 +560,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
+	"importlib-metadata": {
+            "hashes": [
+                "sha256:d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
+                "sha256:d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==5.1.0"
+        },
         "jax": {
             "hashes": [
                 "sha256:b795a75ca2eabb5d20b83f1aa1e1038dafeca89ee74c9ac6e2b919215cadf427"
@@ -1210,6 +1218,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.14.1"
+        },
+	"zipp": {
+            "hashes": [
+                "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
+                "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.11.0"
         }
     },
     "develop": {

--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -124,10 +124,6 @@ sudo -u buildbot python3 -m pip install pipenv
 sudo -u buildbot python3 -m pipenv sync --system
 python3 -m pip install buildbot-worker==2.9.0
 
-# Issue #192: stopgap measure until we sort out this dependency on bullseye.
-python3 -m pip install importlib_metadata
-# End issue #192
-
 TF_PIP=$(sudo -u buildbot python3 -c "import tensorflow as tf; import os; print(os.path.dirname(tf.__file__))")
 
 # temp location until zorg updates


### PR DESCRIPTION
Regenerated the lockfile with Python 3.8 (and ignored some changes in nightly package version numbers) to add in compatibility with Python 3.8 and 3.9 since those versions don't have `importlib-metadata` in the Python standard library like Python 3.10 does.

Also removes the stopgap introduced in cd87863dea0c0f619721794eb5566978ffda0860.

Should close #192.

Tested locally *since the CI is just running duplicate jobs against Python 3.10 for some reason) against all three python versions that we're supporting (3.8, 3.9, and 3.10), and all tests are passing.