### PR TITLE
Fix python version ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,13 @@ jobs:
         task: [Typecheck, Lint, Yapf, Test]
         include:
           - task: Typecheck
-            cmd: pipenv run pytype -j auto .
+            cmd: pytype -j auto .
           - task: Lint
-            cmd: pipenv run pylint --rcfile .pylintrc --recursive yes .
+            cmd: pylint --rcfile .pylintrc --recursive yes .
           - task: Yapf
-            cmd: pipenv run yapf . -drp
+            cmd: yapf . -drp
           - task: Test
-            cmd: pipenv run pytest
+            cmd: pytest
     steps:
       - uses: actions/checkout@v3
       - name: Install Python With Cached pip Packages
@@ -60,6 +60,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: |
           pip3 install pipenv
-          pipenv sync --categories="packages dev-packages ci"
+          pipenv sync --categories="packages dev-packages ci" --system --verbose
       - name: ${{ matrix.task }}
         run: ${{ matrix.cmd }}


### PR DESCRIPTION
My commit to move everything to pipenv also updated the CI to use
pipenv, but pipenv is picking up the wrong Python version when creating
the virtual environment, so all of the jobs are using Python 3.10. This
patch fixes that behavior by having pipenv install the packages to the
system rather than creating a virtual environment.

Work in progress since #193 needs to get merged first so that the CI passes on this.
Currently rebased this branch on top of that branch in my fork so that the commit
is included here.

Should also version-dependent bugs like #192 from getting through CI for the time being again.