### PR TITLE
Make TensorValue pickle-able

### DIFF
--- a/compiler_opt/rl/log_reader.py
+++ b/compiler_opt/rl/log_reader.py
@@ -144,7 +144,6 @@ class TensorValue:
     self._len = slots['_len']
     self._set_view()
 
-
   def __len__(self) -> int:
     return self._len
 

--- a/compiler_opt/rl/log_reader_test.py
+++ b/compiler_opt/rl/log_reader_test.py
@@ -142,7 +142,7 @@ class LogReaderTest(absltest.TestCase):
     fv = r1.feature_values[0]
     s = pickle.dumps(fv)
     self.assertEqual(len(s), 157)
-    o: log_reader.Record = pickle.loads(s)
+    o: log_reader.TensorValue = pickle.loads(s)
     self.assertEqual(len(fv), len(o))
     for i in range(len(fv)):
       self.assertEqual(fv[i], o[i])

--- a/compiler_opt/rl/log_reader_test.py
+++ b/compiler_opt/rl/log_reader_test.py
@@ -138,11 +138,11 @@ class LogReaderTest(absltest.TestCase):
     tf = self.create_tempfile()
     create_example(tf)
     records = list(log_reader.read_log(tf))
-    r1:log_reader.Record = records[0]
+    r1: log_reader.Record = records[0]
     fv = r1.feature_values[0]
     s = pickle.dumps(fv)
     self.assertEqual(len(s), 157)
-    o:log_reader.Record = pickle.loads(s)
+    o: log_reader.Record = pickle.loads(s)
     self.assertEqual(len(fv), len(o))
     for i in range(len(fv)):
       self.assertEqual(fv[i], o[i])

--- a/compiler_opt/rl/log_reader_test.py
+++ b/compiler_opt/rl/log_reader_test.py
@@ -16,6 +16,7 @@
 
 import ctypes
 import json
+import pickle
 from absl.testing import absltest
 from compiler_opt.rl import log_reader
 from typing import BinaryIO
@@ -132,6 +133,19 @@ class LogReaderTest(absltest.TestCase):
       self.assertAlmostEqual(record.score[0], 1.2 + obs_id)
       obs_id += 1
     self.assertEqual(obs_id, 2)
+
+  def test_pickling(self):
+    tf = self.create_tempfile()
+    create_example(tf)
+    records = list(log_reader.read_log(tf))
+    r1:log_reader.Record = records[0]
+    fv = r1.feature_values[0]
+    s = pickle.dumps(fv)
+    self.assertEqual(len(s), 157)
+    o:log_reader.Record = pickle.loads(s)
+    self.assertEqual(len(fv), len(o))
+    for i in range(len(fv)):
+      self.assertEqual(fv[i], o[i])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Logs from optimizations like regalloc need to be "chunked" per context (i.e. per function, in regalloc's case). The bulk of the new log format is the tensor buffers. We could factor the log reader to allow parsing of context sections, but it's simpler (implementation-wise) to convert the whole log on the compilation runner side and then pass python objects around - since the bulk of the data stays unchanged (the bytes buffer underlying the tensor values), and, thus, the overhead is minimal.