### PR TITLE
Refactor early-exit in data_collector into the WorkerPool.

### DIFF
--- a/compiler_opt/distributed/local/local_worker_manager.py
+++ b/compiler_opt/distributed/local/local_worker_manager.py
@@ -218,14 +218,12 @@ def _make_stub(cls: 'type[worker.Worker]', *args, **kwargs):
 
     def set_nice(self, val: int):
       """Sets the nice-ness of the process, this modifies how the OS
-
       schedules it. Only works on Unix, since val is presumed to be an int.
       """
       psutil.Process(self._process.pid).nice(val)
 
     def set_affinity(self, val: List[int]):
       """Sets the CPU affinity of the process, this modifies which cores the OS
-
       schedules it on.
       """
       psutil.Process(self._process.pid).cpu_affinity(val)

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -112,7 +112,6 @@ class LoadedModuleSpec:
 @dataclass(frozen=True)
 class ModuleSpec:
   """Metadata of a compilation unit.
-
   This contains the necessary information to enable corpus operations like
   sampling or filtering, as well as to enable the corpus create
   a LoadedModuleSpec from a CorpusElement.
@@ -133,7 +132,6 @@ class Sampler(metaclass=abc.ABCMeta):
                n: int = 20) -> List[ModuleSpec]:
     """
     Args:
-
       module_specs: list of module_specs to sample from
       k: number of modules to sample
       n: number of buckets to use
@@ -143,7 +141,6 @@ class Sampler(metaclass=abc.ABCMeta):
 
 class SamplerBucketRoundRobin(Sampler):
   """Calls return a list of module_specs sampled randomly from n buckets, in
-
   round-robin order. The buckets are sequential sections of module_specs of
   roughly equal lengths."""
 
@@ -156,7 +153,6 @@ class SamplerBucketRoundRobin(Sampler):
                n: int = 20) -> List[ModuleSpec]:
     """
     Args:
-
       module_specs: list of module_specs to sample from
       k: number of modules to sample
       n: number of buckets to use
@@ -245,10 +241,10 @@ class Corpus:
     Args:
       data_path: corpus directory.
       additional_flags: list of flags to append to the command line
-      delete_flags: list of flags to remove (both `-flag=<value` and 
+      delete_flags: list of flags to remove (both `-flag=<value` and
         `-flag <value>` are supported).
-      replace_flags: list of flags to be replaced. The key in the dictionary is
-        the flag. The value is a string that will be `format`-ed with a
+      replace_flags: list of flags to be replaced. The key in the dictionary
+        is the flag. The value is a string that will be `format`-ed with a
         `context` object - see `ReplaceContext`.
         We verify that flags in replace_flags are present, and do not appear
         in the additional_flags nor delete_flags.

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -112,6 +112,7 @@ class LoadedModuleSpec:
 @dataclass(frozen=True)
 class ModuleSpec:
   """Metadata of a compilation unit.
+
   This contains the necessary information to enable corpus operations like
   sampling or filtering, as well as to enable the corpus create
   a LoadedModuleSpec from a CorpusElement.
@@ -132,6 +133,7 @@ class Sampler(metaclass=abc.ABCMeta):
                n: int = 20) -> List[ModuleSpec]:
     """
     Args:
+
       module_specs: list of module_specs to sample from
       k: number of modules to sample
       n: number of buckets to use
@@ -141,6 +143,7 @@ class Sampler(metaclass=abc.ABCMeta):
 
 class SamplerBucketRoundRobin(Sampler):
   """Calls return a list of module_specs sampled randomly from n buckets, in
+
   round-robin order. The buckets are sequential sections of module_specs of
   roughly equal lengths."""
 
@@ -153,6 +156,7 @@ class SamplerBucketRoundRobin(Sampler):
                n: int = 20) -> List[ModuleSpec]:
     """
     Args:
+
       module_specs: list of module_specs to sample from
       k: number of modules to sample
       n: number of buckets to use
@@ -233,6 +237,7 @@ class Corpus:
                sampler: Sampler = SamplerBucketRoundRobin()):
     """
     Prepares the corpus by pre-loading all the CorpusElements and preparing for
+
     sampling. Command line origin (.cmd file or override) is decided, and final
     command line transformation rules are set (i.e. thinlto flags handled, also
     output) and validated.
@@ -240,10 +245,10 @@ class Corpus:
     Args:
       data_path: corpus directory.
       additional_flags: list of flags to append to the command line
-      delete_flags: list of flags to remove (both `-flag=<value` and
+      delete_flags: list of flags to remove (both `-flag=<value` and 
         `-flag <value>` are supported).
-      replace_flags: list of flags to be replaced. The key in the dictionary
-        is the flag. The value is a string that will be `format`-ed with a
+      replace_flags: list of flags to be replaced. The key in the dictionary is
+        the flag. The value is a string that will be `format`-ed with a
         `context` object - see `ReplaceContext`.
         We verify that flags in replace_flags are present, and do not appear
         in the additional_flags nor delete_flags.

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -37,6 +37,7 @@ from compiler_opt.rl import constant
 from compiler_opt.rl import corpus
 from compiler_opt.rl import data_reader
 from compiler_opt.rl import gin_external_configurables  # pylint: disable=unused-import
+from compiler_opt.rl import data_collector
 from compiler_opt.rl import local_data_collector
 from compiler_opt.rl import policy_saver
 from compiler_opt.rl import random_net_distillation
@@ -61,6 +62,7 @@ FLAGS = flags.FLAGS
 
 @gin.configurable
 def train_eval(worker_manager_class=LocalWorkerPoolManager,
+               use_early_exit_worker_pool=True,
                agent_name=constant.AgentName.PPO,
                warmstart_policy_dir=None,
                num_policy_iterations=0,
@@ -149,7 +151,10 @@ def train_eval(worker_manager_class=LocalWorkerPoolManager,
       worker_class=problem_config.get_runner_type(),
       count=FLAGS.num_workers,
       moving_average_decay_rate=moving_average_decay_rate) as worker_pool:
-    data_collector = local_data_collector.LocalDataCollector(
+    if use_early_exit_worker_pool:
+      logging.info('Constructing early exit worker pool wrapper')
+      worker_pool = data_collector.EarlyExitWorkerPool(worker_pool)
+    train_data_collector = local_data_collector.LocalDataCollector(
         cps=cps,
         num_modules=num_modules,
         worker_pool=worker_pool,
@@ -174,17 +179,17 @@ def train_eval(worker_manager_class=LocalWorkerPoolManager,
                                  str(llvm_trainer.global_step_numpy()))
       saver.save(policy_path)
 
-      dataset_iter, monitor_dict = data_collector.collect_data(
+      dataset_iter, monitor_dict = train_data_collector.collect_data(
           policy=policy_saver.Policy.from_filesystem(
               os.path.join(policy_path, deploy_policy_name)),
           model_id=llvm_trainer.global_step_numpy())
       llvm_trainer.train(dataset_iter, monitor_dict, num_iterations)
 
-      data_collector.on_dataset_consumed(dataset_iter)
+      train_data_collector.on_dataset_consumed(dataset_iter)
 
     # Save final policy.
     saver.save(root_dir)
-    # Wait for all the workers to finish.
+    # Wait for all the workers to finish
     data_collector.close_pool()
 
 

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -189,7 +189,7 @@ def train_eval(worker_manager_class=LocalWorkerPoolManager,
 
     # Save final policy.
     saver.save(root_dir)
-    # Wait for all the workers to finish
+    # Wait for all the workers to finish.
     data_collector.close_pool()
 
 


### PR DESCRIPTION
This is in preparation for an internal fix to speed up compilations on an internal worker pool implementation. The main point is that the checks for exiting early now are abstracted into a worker pool wrapper, so that distributed worker pools can check for early exiting independently of other hosts.