### PR TITLE
Fix bug with positional arguments in the LocalWorkerPool.

### DIFF
--- a/compiler_opt/distributed/local/local_worker_manager.py
+++ b/compiler_opt/distributed/local/local_worker_manager.py
@@ -217,14 +217,12 @@ def _make_stub(cls: 'type[worker.Worker]', *args, **kwargs):
 
     def set_nice(self, val: int):
       """Sets the nice-ness of the process, this modifies how the OS
-
       schedules it. Only works on Unix, since val is presumed to be an int.
       """
       psutil.Process(self._process.pid).nice(val)
 
     def set_affinity(self, val: List[int]):
       """Sets the CPU affinity of the process, this modifies which cores the OS
-
       schedules it on.
       """
       psutil.Process(self._process.pid).cpu_affinity(val)


### PR DESCRIPTION
Positional arguments for worker_class wouldn't work at all when creating a local worker pool, which surprisingly didn't cause any issues previously because we only ever instantiated the pool with kwargs for the worker_class. This is because of how the function signatures for _run and _run_impl were written in local_worker_manager.py. The modified test in this commit would previously fail without the changes in local_worker_manager.py.