### PR TITLE
Simplify scheduling work on a worker pool

### DIFF
--- a/compiler_opt/distributed/buffered_scheduler.py
+++ b/compiler_opt/distributed/buffered_scheduler.py
@@ -19,11 +19,12 @@
 import concurrent.futures
 import threading
 
-from typing import List, Callable, TypeVar
+from typing import Any, Iterable, List, Callable, Tuple, TypeVar
 
 from compiler_opt.distributed import worker
 
 T = TypeVar('T')
+W = TypeVar('W')
 
 
 def schedule(work: List[Callable[[T], worker.WorkerFuture]],
@@ -80,3 +81,32 @@ def schedule(work: List[Callable[[T], worker.WorkerFuture]],
       chain_work(w)
 
   return results
+
+
+def schedule_on_worker_pool(
+    action: Callable[[W, T],
+                     Any], jobs: Iterable[T], worker_pool: worker.WorkerPool
+) -> Tuple[List[W], List[worker.WorkerFuture]]:
+  """
+  Schedule the given action on workers from the given worker pool.
+  Args:
+    action: a function that, given a worker and some args, calls that worker
+      with those args.
+    jobs: a list of arguments, each element constituting a unit of work.
+    worker_pool: the worker pool on which to schedule the work.
+
+  Returns:
+    a tuple. The first value is the workers that are used to perform the work.
+      The second is a list of futures, one for each work item.
+  """
+
+  def work_factory(args):
+
+    def work(w: worker.Worker):
+      return action(w, args)
+
+    return work
+
+  work = [work_factory(job) for job in jobs]
+  workers: List[W] = worker_pool.get_currently_active()
+  return workers, schedule(work, workers, worker_pool.get_worker_concurrency())

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -100,28 +100,24 @@ class LocalDataCollector(data_collector.DataCollector):
     logging.info('Waiting for pending work from last iteration took %f',
                  time.time() - t1)
 
-  def _schedule_jobs(
-      self, policy: policy_saver.Policy, model_id: int,
-      sampled_modules: List[corpus.LoadedModuleSpec]
-  ) -> List[worker.WorkerFuture[compilation_runner.CompilationResult]]:
+  def _schedule_jobs(self, policy: policy_saver.Policy, model_id: int,
+                     sampled_modules: List[corpus.LoadedModuleSpec]) -> None:
     # by now, all the pending work, which was signaled to cancel, must've
     # finished
     self._join_pending_jobs()
-    jobs = [(loaded_module_spec, policy,
-             self._reward_stat_map[loaded_module_spec.name])
-            for loaded_module_spec in sampled_modules]
+    jobs = [
+        dict(
+            loaded_module_spec=loaded_module_spec,
+            policy=policy,
+            reward_stat=self._reward_stat_map[loaded_module_spec.name],
+            model_id=model_id) for loaded_module_spec in sampled_modules
+    ]
 
-    def work_factory(job):
-
-      def work(w: compilation_runner.CompilationRunnerStub):
-        return w.collect_data(*job, model_id=model_id)
-
-      return work
-
-    work = [work_factory(job) for job in jobs]
-    self._workers = self._worker_pool.get_currently_active()
-    return buffered_scheduler.schedule(
-        work, self._workers, self._worker_pool.get_worker_concurrency())
+    (self._workers,
+     self._current_futures) = buffered_scheduler.schedule_on_worker_pool(
+         action=lambda w, kwargs: w.collect_data(**kwargs),
+         jobs=jobs,
+         worker_pool=self._worker_pool)
 
   def collect_data(
       self, policy: policy_saver.Policy, model_id: int
@@ -145,8 +141,7 @@ class LocalDataCollector(data_collector.DataCollector):
     logging.info('resolving prefetched sample took: %d seconds',
                  time.time() - time1)
     self._next_sample = self._prefetch_next_sample()
-    self._current_futures = self._schedule_jobs(policy, model_id,
-                                                sampled_modules)
+    self._schedule_jobs(policy, model_id, sampled_modules)
 
     def wait_for_termination():
       early_exit = self._exit_checker_ctor(num_modules=self._num_modules)


### PR DESCRIPTION
The user can just specify how to call a worker with some work, instead of having to go through the trouble of creating a work factory and so on.