### PR TITLE
Change the return type of buffered_scheduler APIs

### DIFF
--- a/compiler_opt/distributed/buffered_scheduler.py
+++ b/compiler_opt/distributed/buffered_scheduler.py
@@ -29,7 +29,7 @@ W = TypeVar('W')
 
 def schedule(work: List[Callable[[T], worker.WorkerFuture]],
              workers: List[T],
-             buffer=2) -> List[worker.WorkerFuture]:
+             buffer=2) -> List[concurrent.futures.Future]:
   """
   Assigns work to workers once previous work of the worker are
   completed.
@@ -88,7 +88,7 @@ def schedule_on_worker_pool(
     jobs: Iterable[T],
     worker_pool: worker.WorkerPool,
     buffer_size: Optional[int] = None
-) -> Tuple[List[W], List[worker.WorkerFuture]]:
+) -> Tuple[List[W], List[concurrent.futures.Future]]:
   """
   Schedule the given action on workers from the given worker pool.
   Args:

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -170,7 +170,7 @@ class LocalDataCollector(data_collector.DataCollector):
       # now that the workers killed pending compilations, make sure the workers
       # drained their working queues first - they should all complete quickly
       # since the cancellation manager is killing immediately any process starts
-      worker.wait_for(self._current_futures)
+      concurrent.futures.wait(self._current_futures)
       worker.wait_for([wkr.enable() for wkr in self._workers])
 
     self._reset_workers = self._pool.submit(wrapup)


### PR DESCRIPTION
They return canonical futures (i.e. `concurrent.futures.Future`). This is great because we can then use any `Future` APIs, e.g. `concurrent.futures.wait`.