### PR TITLE
Setting `output_dir` for extract_ir_test

### DIFF
--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -23,6 +23,7 @@ from absl.testing import absltest
 from compiler_opt.tools import extract_ir
 
 flags.FLAGS['num_workers'].allow_override = True
+flags.FLAGS['output_dir'].value = ''
 
 
 class ExtractIrTest(absltest.TestCase):


### PR DESCRIPTION
Otherwise the test won't run from the command line.