### PR TITLE
Explicitly `close` & `join` `multiprocessing.Pool` in `extract_ir`

### DIFF
--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -343,6 +343,8 @@ def main(argv):
 
   with multiprocessing.Pool(FLAGS.num_workers) as pool:
     relative_output_paths = pool.map(extract_artifacts, objs)
+    pool.close()
+    pool.join()
 
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written


### PR DESCRIPTION
`Pool.__exit__` just calls `terminate`, but it seems there could be a race condition with the processes that handle `map` and their exiting.