### PR TITLE
Fix extract_ir.py for macos.

### DIFF
--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -78,15 +78,15 @@ flags.mark_flags_as_required(['output_dir'])
 
 flags.DEFINE_string(
     'cmd_section_name', '.llvmcmd',
-    'Name of the section name passed to llvm-objcopy. For linux systems, the '
-    'default .llvmcmd is correct. On macos, one should use __LLVM,__cmdline'
-)
+    'The section name passed to llvm-objcopy. For ELF object files, the '
+    'default .llvmcmd is correct. For Mach-O object files, one should use '
+    'something like __LLVM,__cmdline')
 
 flags.DEFINE_string(
     'bitcode_section_name', '.llvmbc',
-    'Name of the section name passed to llvm-objcopy. For linux systems, the '
-    'default .llvmbc is correct. On macos, one should use __LLVM,__bitcode'
-)
+    'The section name passed to llvm-objcopy. For ELF object files, the '
+    'default .llvmbc is correct. For Mach-O object files, one should use '
+    '__LLVM,__bitcode')
 
 FLAGS = flags.FLAGS
 

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -37,7 +37,6 @@ import pathlib
 import re
 import shutil
 import subprocess
-
 from typing import Dict, List, Optional
 
 from absl import app
@@ -76,6 +75,18 @@ flags.DEFINE_enum(
     'passed in the local case.')
 flags.mark_flags_as_required(['output_dir'])
 
+flags.DEFINE_string(
+    'cmd_section_name', '.llvmcmd',
+    'Name of the section name passed to llvm-objcopy. For linux systems, the '
+    'default .llvmcmd is correct. On macos, one should use __LLVM,__cmdline'
+)
+
+flags.DEFINE_string(
+    'bitcode_section_name', '.llvmbc',
+    'Name of the section name passed to llvm-objcopy. For linux systems, the '
+    'default .llvmbc is correct. On macos, one should use __LLVM,__bitcode'
+)
+
 FLAGS = flags.FLAGS
 
 
@@ -98,10 +109,7 @@ def get_thinlto_index(cmdline: str, basedir: str) -> Optional[str]:
 
 
 class TrainingIRExtractor:
-  """IR and command line extraction from an object file.
-
-  The object file is assumed to have the .llvmbc and .llvmcmd sections.
-  """
+  """IR and command line extraction from an object file."""
 
   def __init__(self, obj_relative_path, output_base_dir, obj_base_dir=None):
     """Set up a TrainingIRExtractor.
@@ -156,16 +164,18 @@ class TrainingIRExtractor:
     return os.path.join(self.dest_dir(), self.module_name() + '.thinlto.bc')
 
   def _get_extraction_cmd_command(self, llvm_objcopy_path):
-    """Call llvm_objcopy to extract the .llvmcmd section in self._cmd_file."""
+    """Call llvm_objcopy to extract the llvmcmd section in self._cmd_file."""
     return [
-        llvm_objcopy_path, '--dump-section=.llvmcmd=' + self.cmd_file(),
+        llvm_objcopy_path,
+        '--dump-section=' + FLAGS.cmd_section_name + '=' + self.cmd_file(),
         self.input_obj(), '/dev/null'
     ]
 
   def _get_extraction_bc_command(self, llvm_objcopy_path):
-    """Call llvm_objcopy to extract the .llvmbc section in self._bc_file."""
+    """Call llvm_objcopy to extract the llvmbc section in self._bc_file."""
     return [
-        llvm_objcopy_path, '--dump-section=.llvmbc=' + self.bc_file(),
+        llvm_objcopy_path,
+        '--dump-section=' + FLAGS.bitcode_section_name + '=' + self.bc_file(),
         self.input_obj(), '/dev/null'
     ]
 
@@ -318,6 +328,7 @@ def extract_artifacts(obj: TrainingIRExtractor) -> Optional[str]:
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
+  flags.mark_flags_as_required(['output_dir'])
 
   objs = []
   if FLAGS.input is not None and FLAGS.thinlto_build == 'local':
@@ -343,8 +354,6 @@ def main(argv):
 
   with multiprocessing.Pool(FLAGS.num_workers) as pool:
     relative_output_paths = pool.map(extract_artifacts, objs)
-    pool.close()
-    pool.join()
 
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written
@@ -371,4 +380,5 @@ def main(argv):
 
 
 if __name__ == '__main__':
+  multiprocessing.set_start_method('fork')
   app.run(main)

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -37,6 +37,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+
 from typing import Dict, List, Optional
 
 from absl import app
@@ -328,7 +329,6 @@ def extract_artifacts(obj: TrainingIRExtractor) -> Optional[str]:
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
-  flags.mark_flags_as_required(['output_dir'])
 
   objs = []
   if FLAGS.input is not None and FLAGS.thinlto_build == 'local':
@@ -354,6 +354,8 @@ def main(argv):
 
   with multiprocessing.Pool(FLAGS.num_workers) as pool:
     relative_output_paths = pool.map(extract_artifacts, objs)
+    pool.close()
+    pool.join()
 
   # This comes first rather than later so global_command_override is at the top
   # of the .json after being written


### PR DESCRIPTION
For whatever reason, the section names for .llvmcmd and .llvmbc are different on macos. One problem is that macos uses macho object files instead of elf, so in addition to the section names there are segment names that need to be specified. The other problem is that regardless of the segments, the section names are different. This patch makes the segment name configurable by a flag, and gives sensible defaults for linux + documentation for macos.