### PR TITLE
Quick CI Fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: Pipfile.lock
       - name: Install Python, no cache
         if: needs.Envvars.outputs.do_cache == '0'
         uses: actions/setup-python@v4


### PR DESCRIPTION
The last patch removed the remaining requirements.txt as it was leftover from the pipenv transition. However, this broke the CI as setup-python's cache is set to pip which depends upon the hash of a requirements.txt. This implements a quick fix by setting the cache dependency path (used for the hash) to the Pipfile.lock. This is not optimal since the pipenv deps don't get cached (based on my testing), but they weren't before either (as far as I can tell). More testing is needed, but this should get the CI green.