### PR TITLE
Fix caching in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,15 +52,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: 'pipenv'
           cache-dependency-path: Pipfile.lock
       - name: Install Python, no cache
         if: needs.Envvars.outputs.do_cache == '0'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: |
-          pip3 install pipenv
-          pipenv sync --categories="packages dev-packages ci" --system --verbose
+      - name: Install Pipenv
+        run: pip3 install pipenv
+      - name: Install Python Dependencies
+        run: pipenv sync --categories="packages dev-packages ci" --verbose
       - name: ${{ matrix.task }}
-        run: ${{ matrix.cmd }}
+        run: pipenv run ${{ matrix.cmd }}
+


### PR DESCRIPTION
This fixes the caching for python dependencies in the CI by making pipenv install in a virtual environment and telling the setup-python action to cache this venv as it doesn't currently support the global pipenv cache. This increases the speed of some of the fast jobs (like the yapf format checker) quite a bit. Formatting went from about 2.5min to about 0.7min in my testing. This assumes that the cache is warm.