### PR TITLE
Add pyproject.toml to enable packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 __pycache__
 .vscode
 .idea
+
+# Python packaging build directories
+build/*
+dist/*
+ml_compiler_opt.egg-info/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ml-compiler-opt"
+description = "Tooling for ML in LLVM"
+readme = "README.md"
+requires-python = ">=3.8,<3.11"
+dependencies = [
+  "absl-py>=1.0.0",
+  "gin-config>=0.5.0",
+  "psutil>=5.9.0",
+  "tf-agents>=0.16.0",
+  "tensorflow>=2.12.0",
+  "dm-reverb>=0.11.0"
+]
+version="0.0.1"
+
+[tool.setuptools.packages.find]
+include = ["compiler_opt*"]
+


### PR DESCRIPTION
Adds a basic `pyproject.toml` so that we can package the ML python tooling for use outside of the repository.