### PR TITLE
Add packaging CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,30 @@
+name: MLGO Packaging CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  BuildAndPublich:
+    runs-on: ubuntu-latest
+    name: Build and Publish Package
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout repository
+      - uses: actions/setup-python@v4
+        name: Setup Python
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip3 install build==0.1.0 setuptools==67.8.0 twine==4.0.2
+        name: Install Packaging Dependencies
+        # TODO(boomanaiden154): Switch this install step over to using pipenv
+        # once regenerating the lockfile has been fixed.
+      - run: python3 -m build
+        name: Build package
+      - run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{secrets.PYPI_TOKEN}}
+        name: Publish the package

--- a/compiler_opt/package_config.py
+++ b/compiler_opt/package_config.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup version information for the package."""
+
+from datetime import timezone, datetime
+
+__version__ = '0.0.1.dev' + datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ dependencies = [
   "tensorflow>=2.12.0",
   "dm-reverb>=0.11.0"
 ]
-version="0.0.1"
+dynamic = ["version"]
 
 [tool.setuptools.packages.find]
 include = ["compiler_opt*"]
 
+[tool.setuptools.dynamic]
+version = {attr = "compiler_opt.package_config.__version__"}


### PR DESCRIPTION
This commits adds in infrastructure to push package builds to Pypi nightly and on command. This all changes the versioning of the python package from a single fixed value to a dynamically generated value that includes the current date/time.

This shouldn't introduce too much maintenance burden on other maintainers as it is relatively self-maintained within the repository. 

I would've preferred to not have to introduce a new `package_config.py`, but adding a `__version__` attribute to `__init__.py` causes setuptools to complain about `absl` not being present as it isn't included in the build environment and placing the Python file somewhere else causes build failures as it doesn't get included in the final package.

I would like to add packaging dependencies to the `Pipfile`, but currently regenerating the lockfile causes build failures. I need to do some more investigation there, but I'm just pushing it forward for now.

This will require a bit of additional setup, namely adding a Pypi token to the Github actions secrets, but this should be relatively trivial.