### PR TITLE
Add logging verbosity level flag to extract_ir.py

### DIFF
--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -30,9 +30,9 @@ In a local ThinLTO case, the compilation is assumedto have been performed
 specifying -Wl,--save-temps=import -Wl,--thinlto-emit-index-files
 
 To change the logging verbosity, pass an integer representing the desired
-verbosity to the --verbosity flag. Use 0 for all logs and detailed debug
-information, -1 for solely warnings, and -2 to only print a status message at
-the end.
+verbosity to the --verbosity flag. Use 0 for all logs, status information, 
+and detailed debug information, -1 for solely warnings, and -2 to not produce
+any output.
 """
 
 import json
@@ -132,9 +132,6 @@ def main(argv):
 
   extract_ir_lib.write_corpus_manifest(FLAGS.thinlto_build,
                                        relative_output_paths, FLAGS.output_dir)
-
-  # Reset logging verbosity so that we print status messages
-  logging.set_verbosity(logging.INFO)
 
   logging.info('Converted %d files out of %d',
                len(objs) - relative_output_paths.count(None), len(objs))

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -30,7 +30,7 @@ In a local ThinLTO case, the compilation is assumedto have been performed
 specifying -Wl,--save-temps=import -Wl,--thinlto-emit-index-files
 
 To change the logging verbosity, pass an integer representing the desired
-verbosity to the --verbosity flag. Use 0 for all logs, status information, 
+verbosity to the --verbosity flag. Use 0 for all logs, status information,
 and detailed debug information, -1 for solely warnings, and -2 to not produce
 any output.
 """

--- a/compiler_opt/tools/extract_ir.py
+++ b/compiler_opt/tools/extract_ir.py
@@ -28,6 +28,11 @@ specifying -mllvm -lto-embed-bitcode=post-merge-pre-opt.
 
 In a local ThinLTO case, the compilation is assumedto have been performed
 specifying -Wl,--save-temps=import -Wl,--thinlto-emit-index-files
+
+To change the logging verbosity, pass an integer representing the desired
+verbosity to the --verbosity flag. Use 0 for all logs and detailed debug
+information, -1 for solely warnings, and -2 to only print a status message at
+the end.
 """
 
 import json
@@ -127,6 +132,9 @@ def main(argv):
 
   extract_ir_lib.write_corpus_manifest(FLAGS.thinlto_build,
                                        relative_output_paths, FLAGS.output_dir)
+
+  # Reset logging verbosity so that we print status messages
+  logging.set_verbosity(logging.INFO)
 
   logging.info('Converted %d files out of %d',
                len(objs) - relative_output_paths.count(None), len(objs))

--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -134,40 +134,35 @@ class TrainingIRExtractor:
       logging.info('%s does not exist.', self.input_obj())
       return None
     os.makedirs(self.dest_dir(), exist_ok=True)
-    cmd_objcopy_output = subprocess.run(
-        self._get_extraction_cmd_command(llvm_objcopy_path, cmd_section_name),
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True)
-    if cmd_objcopy_output.returncode != 0:
-      logging.warning('%s was not processed.', self.input_obj())
-      logging.info(cmd_objcopy_output.stdout)
-      return None
-    if cmd_filter is not None or is_thinlto:
-      with open(self.cmd_file(), encoding='utf-8') as f:
-        lines = f.readlines()
-      assert len(lines) == 1
-      cmdline = lines[0]
-      if not should_include_module(cmdline, cmd_filter):
-        logging.info('Excluding module %s because it does not match the filter',
-                     self.input_obj())
-        os.remove(self.cmd_file())
-        return None
-      if is_thinlto:
-        index_file = get_thinlto_index(cmdline, self.obj_base_dir())
-        shutil.copy(index_file, self.thinlto_index_file())
+    try:
+      subprocess.check_output(
+          self._get_extraction_cmd_command(llvm_objcopy_path, cmd_section_name),
+          stderr=subprocess.STDOUT,
+          encoding='utf-8')
+      if cmd_filter is not None or is_thinlto:
+        with open(self.cmd_file(), encoding='utf-8') as f:
+          lines = f.readlines()
+        assert len(lines) == 1
+        cmdline = lines[0]
+        if not should_include_module(cmdline, cmd_filter):
+          logging.info(
+              'Excluding module %s because it does not match the filter',
+              self.input_obj())
+          os.remove(self.cmd_file())
+          return None
+        if is_thinlto:
+          index_file = get_thinlto_index(cmdline, self.obj_base_dir())
+          shutil.copy(index_file, self.thinlto_index_file())
 
-    bc_objcopy_output = subprocess.run(
-        self._get_extraction_bc_command(llvm_objcopy_path,
-                                        bitcode_section_name),
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True)
-    if bc_objcopy_output.returncode != 0:
-      logging.warning('%s was not processed.', self.input_obj())
-      logging.info(bc_objcopy_output.stdout)
+      subprocess.check_output(
+          self._get_extraction_bc_command(llvm_objcopy_path,
+                                          bitcode_section_name),
+          stderr=subprocess.STDOUT,
+          encoding='utf-8')
+    except subprocess.CalledProcessError as e:
+      # This may happen if  .o file was build from asm (.S source).
+      logging.warning('%s was not processed: %s', self.input_obj(), e)
+      logging.info(e.output)
       return None
     assert (os.path.exists(self.cmd_file()) and
             os.path.exists(self.bc_file()) and

--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -135,9 +135,13 @@ class TrainingIRExtractor:
       return None
     os.makedirs(self.dest_dir(), exist_ok=True)
     try:
+      subprocess_output = None if logging.get_verbosity(
+      ) == logging.INFO else subprocess.DEVNULL
       subprocess.run(
           self._get_extraction_cmd_command(llvm_objcopy_path, cmd_section_name),
-          check=True)
+          check=True,
+          stdout=subprocess_output,
+          stderr=subprocess_output)
       if cmd_filter is not None or is_thinlto:
         with open(self.cmd_file(), encoding='utf-8') as f:
           lines = f.readlines()


### PR DESCRIPTION
This commit adds a logging verbosity level flag to extract_ir.py and the appropriate plumbing/implementation in extract_ir_lib.py. This is primarily motivated by these errors coming up quite often in non-trivial builds (as it is fairly often there is some assembly or some flags don't get passed around somewhere) and not providing a very high signal to noise ratio, especially when used as a library against a bunch of projects at once.

I've implemented this as a custom flag rather than using absl's `logging.get_verbosity` and `logging.set_verbosity` as I think this approach is a bit more expressive for the purposes here, and it also avoids us needing to set global state which is nice within the project and especially for downstream users (although it's not a big switch to do so the other method). I'm open to switching over if others have different ideas.