### PR TITLE
Make make_corpus functions consistent with extract_ir functions

### DIFF
--- a/compiler_opt/tools/make_corpus_lib.py
+++ b/compiler_opt/tools/make_corpus_lib.py
@@ -21,6 +21,8 @@ import json
 
 from typing import List, Optional
 
+BITCODE_EXTENSION = '.bc'
+
 
 def load_bitcode_from_directory(bitcode_base_dir: str) -> List[str]:
   """Finds bitcode files to extract from a given directory.
@@ -33,7 +35,10 @@ def load_bitcode_from_directory(bitcode_base_dir: str) -> List[str]:
   Returns an array of paths representing the relative path to the bitcode
   file from the base direcotry.
   """
-  paths = [str(p) for p in pathlib.Path(bitcode_base_dir).glob('**/*.bc')]
+  paths = [
+      str(p)[:-len(BITCODE_EXTENSION)]
+      for p in pathlib.Path(bitcode_base_dir).glob('**/*' + BITCODE_EXTENSION)
+  ]
 
   return [
       os.path.relpath(full_path, start=bitcode_base_dir) for full_path in paths
@@ -51,8 +56,10 @@ def copy_bitcode(relative_paths: List[str], bitcode_base_dir: str,
     output_dir: The output directory to place the bitcode in.
   """
   for relative_path in relative_paths:
-    base_path = os.path.join(bitcode_base_dir, relative_path)
-    destination_path = os.path.join(output_dir, relative_path)
+    base_path = os.path.join(bitcode_base_dir,
+                             relative_path + BITCODE_EXTENSION)
+    destination_path = os.path.join(output_dir,
+                                    relative_path + BITCODE_EXTENSION)
     os.makedirs(os.path.dirname(destination_path), exist_ok=True)
     shutil.copy(base_path, destination_path)
 

--- a/compiler_opt/tools/make_corpus_test.py
+++ b/compiler_opt/tools/make_corpus_test.py
@@ -31,15 +31,15 @@ class MakeCorpusTest(absltest.TestCase):
     tempdir.create_file('test2.bc')
     relative_paths = make_corpus_lib.load_bitcode_from_directory(outer)
     relative_paths = sorted(relative_paths)
-    self.assertEqual(relative_paths[0], 'nested/test1.bc')
-    self.assertEqual(relative_paths[1], 'nested/test2.bc')
+    self.assertEqual(relative_paths[0], 'nested/test1')
+    self.assertEqual(relative_paths[1], 'nested/test2')
 
   def test_copy_bitcode(self):
     build_dir = self.create_tempdir()
     nested_dir = build_dir.mkdir(dir_path='nested')
     nested_dir.create_file('test1.bc')
     nested_dir.create_file('test2.bc')
-    relative_paths = ['nested/test1.bc', 'nested/test2.bc']
+    relative_paths = ['nested/test1', 'nested/test2']
     corpus_dir = self.create_tempdir()
     make_corpus_lib.copy_bitcode(relative_paths, build_dir, corpus_dir)
     output_files = sorted(os.listdir(os.path.join(corpus_dir, './nested')))
@@ -47,7 +47,7 @@ class MakeCorpusTest(absltest.TestCase):
     self.assertEqual(output_files[1], 'test2.bc')
 
   def test_write_corpus_manifest(self):
-    relative_output_paths = ['test/test1.bc', 'test/test2.bc']
+    relative_output_paths = ['test/test1', 'test/test2']
     output_dir = self.create_tempdir()
     default_args = ['-O3', '-c']
     make_corpus_lib.write_corpus_manifest(relative_output_paths, output_dir,


### PR DESCRIPTION
Currently the functions in make_corpus_lib assume they are working with a full file path whereas the tooling in extract_ir truncates the .bc/.cmd extensions and only has the object file. This discrepancy means that tooling that works with downstream products of corpora from extract_ir doesn't work without modification with corpora from make_corpus (ignoring the missing .cmd files). This patch makes make_corpus match the behavior of extract_ir.