### PR TITLE
Fix make_corpus warning message

### DIFF
--- a/compiler_opt/tools/make_corpus.py
+++ b/compiler_opt/tools/make_corpus.py
@@ -42,10 +42,11 @@ FLAGS = flags.FLAGS
 
 
 def main(_):
-  logging.warn('Using this tool does not guarnatee that the bitcode is taken at'
-               'the correct stage for consumption during model training. Make'
-               'sure to validate assumptions about where the bitcode is coming'
-               'from before using it in production.')
+  logging.warning(
+      'Using this tool does not guarantee that the bitcode is taken at '
+      'the correct stage for consumption during model training. Make '
+      'sure to validate assumptions about where the bitcode is coming '
+      'from before using it in production.')
   relative_paths = make_corpus_lib.load_bitcode_from_directory(FLAGS.input_dir)
   make_corpus_lib.copy_bitcode(relative_paths, FLAGS.input_dir,
                                FLAGS.output_dir)


### PR DESCRIPTION
Currently, the warning message is specified using logging.warn rather than logging.warning and the former is deprecated. This patch also adds appropriate spacing and fixes spelling to make the message appear as intended.