### PR TITLE
Fix combine_training_corpus.py

### DIFF
--- a/compiler_opt/tools/combine_training_corpus.py
+++ b/compiler_opt/tools/combine_training_corpus.py
@@ -48,8 +48,8 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
+  combine_training_corpus_lib.combine_corpus(FLAGS.root_dir)
 
-combine_training_corpus_lib.combine_corpus(FLAGS.root_dir)
 
 if __name__ == '__main__':
   app.run(main)


### PR DESCRIPTION
My last patch to the file refactoring it into a separate library inadvertantly broke the actual script as I removed the indentation from the statement calling into the library. This means the library never actually gets called with the correct arguments and it doesn't end up working properly.