### PR TITLE
Add support for `arguments`-style compilation databases (#297)

### DIFF
--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -207,14 +207,20 @@ class TrainingIRExtractor:
 def convert_compile_command_to_objectfile(
     command: Dict[str, str], output_dir: str) -> Optional[TrainingIRExtractor]:
   obj_base_dir = command['directory']
-  cmd = command['command']
+  if 'arguments' in command:
+    cmd_parts = command['arguments']
+  elif 'command' in command:
+    cmd_parts = command['command'].split()
+  else:
+    logging.info('compile_commands element has no command and arguments: %s',
+                 cmd_parts)
+    return None
 
-  cmd_parts = cmd.split()
   try:
     obj_index = cmd_parts.index('-o') + 1
   except ValueError:
     # This could happen if there are non-clang commands in compile_commands.json
-    logging.info('Command has no -o option: %s', cmd)
+    logging.info('Command has no -o option: %s', cmd_parts)
     return None
   obj_rel_path = cmd_parts[obj_index]
   # TODO(mtrofin): is the obj_base_dir correct for thinlto index bc files?

--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -212,7 +212,7 @@ def convert_compile_command_to_objectfile(
   elif 'command' in command:
     cmd_parts = command['command'].split()
   else:
-    logging.info('compile_commands element has no command and arguments)
+    logging.info('compile_commands element has no command and arguments')
     return None
 
   try:

--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -212,8 +212,7 @@ def convert_compile_command_to_objectfile(
   elif 'command' in command:
     cmd_parts = command['command'].split()
   else:
-    logging.info('compile_commands element has no command and arguments: %s',
-                 cmd_parts)
+    logging.info('compile_commands element has no command and arguments)
     return None
 
   try:

--- a/compiler_opt/tools/extract_ir_lib.py
+++ b/compiler_opt/tools/extract_ir_lib.py
@@ -219,7 +219,7 @@ def convert_compile_command_to_objectfile(
     obj_index = cmd_parts.index('-o') + 1
   except ValueError:
     # This could happen if there are non-clang commands in compile_commands.json
-    logging.info('Command has no -o option: %s', cmd_parts)
+    logging.info('Command has no -o option: %s', ' '.join(cmd_parts))
     return None
   obj_rel_path = cmd_parts[obj_index]
   # TODO(mtrofin): is the obj_base_dir correct for thinlto index bc files?

--- a/compiler_opt/tools/extract_ir_test.py
+++ b/compiler_opt/tools/extract_ir_test.py
@@ -42,6 +42,25 @@ class ExtractIrTest(absltest.TestCase):
                      '/corpus/destination/path/lib/bar.o.thinlto.bc')
     # pytype: enable=attribute-error
 
+  def test_one_conversion_arguments_style(self):
+    obj = extract_ir_lib.convert_compile_command_to_objectfile(
+        {
+            'directory': '/output/directory',
+            'arguments':
+                ['-cc1', '-c', '/some/path/lib/foo/bar.cc', '-o', 'lib/bar.o'],
+            'file': '/some/path/lib/foo/bar.cc'
+        }, '/corpus/destination/path')
+    self.assertIsNotNone(obj)
+    # pytype: disable=attribute-error
+    # Pytype complains about obj being None
+    self.assertEqual(obj.input_obj(), '/output/directory/lib/bar.o')
+    self.assertEqual(obj.relative_output_path(), 'lib/bar.o')
+    self.assertEqual(obj.cmd_file(), '/corpus/destination/path/lib/bar.o.cmd')
+    self.assertEqual(obj.bc_file(), '/corpus/destination/path/lib/bar.o.bc')
+    self.assertEqual(obj.thinlto_index_file(),
+                     '/corpus/destination/path/lib/bar.o.thinlto.bc')
+    # pytype: enable=attribute-error
+
   def test_arr_conversion(self):
     res = extract_ir_lib.load_from_compile_commands([{
         'directory': '/output/directory',


### PR DESCRIPTION
Fixes #297