### PR TITLE
Unify scalar type associations

### DIFF
--- a/compiler_opt/rl/log_reader.py
+++ b/compiler_opt/rl/log_reader.py
@@ -61,29 +61,17 @@ import dataclasses
 import json
 import math
 
+from compiler_opt import type_map
 from typing import Any, BinaryIO, Dict, Generator, List, Optional, Union
 import numpy as np
 import tensorflow as tf
 
-_element_type_name_map = {
-    'float': (ctypes.c_float, tf.float32),
-    'double': (ctypes.c_double, tf.float64),
-    'int8_t': (ctypes.c_int8, tf.int8),
-    'uint8_t': (ctypes.c_uint8, tf.uint8),
-    'int16_t': (ctypes.c_int16, tf.int16),
-    'uint16_t': (ctypes.c_uint16, tf.uint16),
-    'int32_t': (ctypes.c_int32, tf.int32),
-    'uint32_t': (ctypes.c_uint32, tf.uint32),
-    'int64_t': (ctypes.c_int64, tf.int64),
-    'uint64_t': (ctypes.c_uint64, tf.uint64)
-}
-
 _element_type_name_to_dtype = {
-    name: dtype for name, (_, dtype) in _element_type_name_map.items()
+    name: dtype for name, _, dtype in type_map.TYPE_ASSOCIATIONS
 }
 
 _dtype_to_ctype = {
-    dtype: ctype for _, (ctype, dtype) in _element_type_name_map.items()
+    dtype: ctype for _, ctype, dtype in type_map.TYPE_ASSOCIATIONS
 }
 
 

--- a/compiler_opt/rl/log_reader.py
+++ b/compiler_opt/rl/log_reader.py
@@ -62,7 +62,7 @@ import json
 import math
 
 from compiler_opt import type_map
-from typing import Any, BinaryIO, Dict, Generator, List, Optional, Union
+from typing import Any, BinaryIO, Dict, Generator, List, Optional
 import numpy as np
 import tensorflow as tf
 
@@ -73,11 +73,6 @@ _element_type_name_to_dtype = {
 _dtype_to_ctype = {
     dtype: ctype for _, ctype, dtype in type_map.TYPE_ASSOCIATIONS
 }
-
-
-def convert_dtype_to_ctype(dtype: str) -> Union[type, tf.dtypes.DType]:
-  """Public interface for the _dtype_to_ctype dict."""
-  return _dtype_to_ctype[dtype]
 
 
 def create_tensorspec(d: Dict[str, Any]) -> tf.TensorSpec:
@@ -116,9 +111,7 @@ class LogReaderTensorValue:
 
   def to_numpy(self) -> np.ndarray:
     return np.frombuffer(
-        self._buffer,
-        dtype=convert_dtype_to_ctype(self._spec.dtype),
-        count=self._len)
+        self._buffer, dtype=_dtype_to_ctype[self._spec.dtype], count=self._len)
 
   def _set_view(self):
     # c_char_p is a nul-terminated string, so the more appropriate cast here

--- a/compiler_opt/rl/policy_saver.py
+++ b/compiler_opt/rl/policy_saver.py
@@ -18,6 +18,8 @@ import dataclasses
 import json
 import os
 
+from compiler_opt import type_map
+
 import tensorflow as tf
 from tf_agents.policies import tf_policy
 from tf_agents.policies import policy_saver
@@ -27,17 +29,8 @@ from typing import Dict, Tuple
 OUTPUT_SIGNATURE = 'output_spec.json'
 TFLITE_MODEL_NAME = 'model.tflite'
 
-_TYPE_CONVERSION_DICT = {
-    tf.float32: 'float',
-    tf.float64: 'double',
-    tf.int8: 'int8_t',
-    tf.uint8: 'uint8_t',
-    tf.int16: 'int16_t',
-    tf.uint16: 'uint16_t',
-    tf.int32: 'int32_t',
-    tf.uint32: 'uint32_t',
-    tf.int64: 'int64_t',
-    tf.uint64: 'uint64_t',
+_dtype_to_name_map = {
+    dtype: name for name, _, dtype in type_map.TYPE_ASSOCIATIONS
 }
 
 
@@ -215,7 +208,7 @@ class PolicySaver(object):
         'tensor_spec': {
             'name': tensor_op,
             'port': tensor_port,
-            'type': _TYPE_CONVERSION_DICT[sm_action_decision.dtype],
+            'type': _dtype_to_name_map[sm_action_decision.dtype],
             'shape': sm_action_decision.shape.as_list(),
         }
     }]
@@ -229,7 +222,7 @@ class PolicySaver(object):
           'tensor_spec': {
               'name': tensor_op,
               'port': tensor_port,
-              'type': _TYPE_CONVERSION_DICT[sm_action_info.dtype],
+              'type': _dtype_to_name_map[sm_action_info.dtype],
               'shape': sm_action_info.shape.as_list(),
           }
       })

--- a/compiler_opt/type_map.py
+++ b/compiler_opt/type_map.py
@@ -14,19 +14,14 @@
 # limitations under the License.
 """Map between tf, ctypes, and string names for scalar types."""
 import ctypes
-from typing import Any, List, Tuple, Union
+from typing import List, Tuple, Union
 import tensorflow as tf
-import sys
 
-# ctypes doesn't have a 'ctype base type' that'd also be public.
-if sys.version_info.minor < 9:
-  ScalarCType = Any
-else:
-  ScalarCType = Union[type[ctypes.c_float], type[ctypes.c_double],
-                      type[ctypes.c_int8], type[ctypes.c_int16],
-                      type[ctypes.c_uint16], type[ctypes.c_int32],
-                      type[ctypes.c_uint32], type[ctypes.c_int64],
-                      type[ctypes.c_uint64]]
+ScalarCType = Union['type[ctypes.c_float]', 'type[ctypes.c_double]',
+                    'type[ctypes.c_int8]', 'type[ctypes.c_int16]',
+                    'type[ctypes.c_uint16]', 'type[ctypes.c_int32]',
+                    'type[ctypes.c_uint32]', 'type[ctypes.c_int64]',
+                    'type[ctypes.c_uint64]']
 
 TYPE_ASSOCIATIONS: List[Tuple[str, ScalarCType,
                               tf.DType]] = [

--- a/compiler_opt/type_map.py
+++ b/compiler_opt/type_map.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Map between tf, ctypes, and string names for scalar types."""
+import ctypes
+from typing import Any, List, Tuple, Union
+import tensorflow as tf
+import sys
+
+# ctypes doesn't have a 'ctype base type' that'd also be public.
+if sys.version_info.minor < 9:
+  ScalarCType = Any
+else:
+  ScalarCType = Union[type[ctypes.c_float], type[ctypes.c_double],
+                      type[ctypes.c_int8], type[ctypes.c_int16],
+                      type[ctypes.c_uint16], type[ctypes.c_int32],
+                      type[ctypes.c_uint32], type[ctypes.c_int64],
+                      type[ctypes.c_uint64]]
+
+TYPE_ASSOCIATIONS: List[Tuple[str, ScalarCType,
+                              tf.DType]] = [
+                                  ('float', ctypes.c_float, tf.float32),
+                                  ('double', ctypes.c_double, tf.float64),
+                                  ('int8_t', ctypes.c_int8, tf.int8),
+                                  ('uint8_t', ctypes.c_uint8, tf.uint8),
+                                  ('int16_t', ctypes.c_int16, tf.int16),
+                                  ('uint16_t', ctypes.c_uint16, tf.uint16),
+                                  ('int32_t', ctypes.c_int32, tf.int32),
+                                  ('uint32_t', ctypes.c_uint32, tf.uint32),
+                                  ('int64_t', ctypes.c_int64, tf.int64),
+                                  ('uint64_t', ctypes.c_uint64, tf.uint64)
+                              ]


### PR DESCRIPTION
We have 3 scalar type representations: tensorflow, ctypes, and string names. Not unlikely we may get a fourth, numpy. This patch factors out all the associations into a central place. Modules can build their own maps as needed from it (i.e. name->ctype or dtype->name, etc)