### PR TITLE
Install pytype on buildbot

### DIFF
--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -122,7 +122,7 @@ wget --quiet https://raw.githubusercontent.com/google/ml-compiler-opt/main/Pipfi
 
 # install the tf pip package for the AOT ("release" scenario).
 sudo -u buildbot python3 -m pip install pipenv
-sudo -u buildbot python3 -m pipenv sync --system
+sudo -u buildbot python3 -m pipenv sync --categories "packages dev-packages" --system
 python3 -m pip install buildbot-worker==2.9.0
 
 TF_PIP=$(sudo -u buildbot python3 -c "import tensorflow as tf; import os; print(os.path.dirname(tf.__file__))")


### PR DESCRIPTION
This patch installs the development dependencies on the buildbot in addition to the normal python dependencies so that we have pytype available. This is necessary for running the pytype tests recently added on the LLVM side so we can prevent regressions while waiting for precommit CI to be implemented on the LLVM side.