### PR TITLE
docs: regalloc-demo: Fix a typo in corpus extraction command

### DIFF
--- a/docs/regalloc-demo/demo.md
+++ b/docs/regalloc-demo/demo.md
@@ -297,7 +297,7 @@ running the following command to do the initial step in the corpus extraction
 process:
 
 ```bash
-extract_ir.py \
+extract_ir \
   --cmd_filter="^-O2|-O3" \
   --llvm_objcopy_path=$WORKING_DIR/llvm-build/bin/llvm-objcopy \
   --output_dir=$WORKING_DIR/corpus \


### PR DESCRIPTION
Fixes a leftover from https://github.com/google/ml-compiler-opt/commit/7a62027deb1ee226e5bd243140b47dc21fcec854