### PR TITLE
Misc improvements to inlining evaluation docs in demo

### DIFF
--- a/docs/inlining-demo/demo.md
+++ b/docs/inlining-demo/demo.md
@@ -332,14 +332,14 @@ size under the trained policy at `$OUTPUT_PERFORMANCE_PATH`.
 
 ```shell
 export OUTPUT_PERFORMANCE_PATH=$HOME/performance_report && \
-PYTHONPATH=$PYTHONPATH:. && \
-python3 compiler_opt/tools/generate_default_trace.py \
+PYTHONPATH=$PYTHONPATH:. python3 \
+compiler_opt/tools/generate_default_trace.py \
   --data_path=$CORPUS \
   --policy_path=$OUTPUT_DIR/saved_policy \
   --output_performance_path=$OUTPUT_PERFORMANCE_PATH \
   --gin_files=compiler_opt/rl/inlining/gin_configs/common.gin \
   --gin_bindings=clang_path="'$LLVM_INSTALLDIR/bin/clang'" \
-  --gin_bindings=llvm_size_path"'=$LLVM_INSTALLDIR/bin/llvm-size'" \
+  --gin_bindings=llvm_size_path="'$LLVM_INSTALLDIR/bin/llvm-size'" \
   --sampling_rate=0.2
 ```
 

--- a/docs/inlining-demo/demo.md
+++ b/docs/inlining-demo/demo.md
@@ -337,7 +337,6 @@ python3 compiler_opt/tools/generate_default_trace.py \
   --data_path=$CORPUS \
   --policy_path=$OUTPUT_DIR/saved_policy \
   --output_performance_path=$OUTPUT_PERFORMANCE_PATH \
-  --compile_task=inlining \
   --gin_files=compiler_opt/rl/inlining/gin_configs/common.gin \
   --gin_bindings=clang_path="'$LLVM_INSTALLDIR/bin/clang'" \
   --gin_bindings=llvm_size_path"'=$LLVM_INSTALLDIR/bin/llvm-size'" \


### PR DESCRIPTION
This patch removes the compile_task flag from the evaluation documentation for the inliner demo. This flag was removed in 2ba448732b5c9aa9ed221ac70a0009293651701e and the documentation was never updated.

Fixes #340.