### PR TITLE
Restrict push CI to main, fix permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
   LicenseCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./check-license.sh
   Envvars:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
           - task: Test
             cmd: pytest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Python With Cached pip Packages
         if: needs.Envvars.outputs.do_cache == '1'
         uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,14 +57,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Python With Cached pip Packages
         if: needs.Envvars.outputs.do_cache == '1'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pipenv'
           cache-dependency-path: Pipfile.lock
       - name: Install Python, no cache
         if: needs.Envvars.outputs.do_cache == '0'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Pipenv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,15 @@
 
 name: MLGO CI
 
-on: [push, repository_dispatch, pull_request]
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'main'
+  repository_dispatch:
+  pull_request:
 
 jobs:
   LicenseCheck:


### PR DESCRIPTION
This patch makes two primary changes to the CI config. It restricts the CI running on push events to only run on the main branch. This prevents the CI from running twice on PRs from branches in the main repository, which are needed for stacked PRs.

Additionally, this PR sets the permissions at the top of the file, which is a general best practice for Github workflows for security reasons.

Additionally, bump a couple of the actions that were using deprecated NodeJS versions so we do not get the warning anymore.