### PR TITLE
Refactor test ESWorker to separate class

### DIFF
--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -20,7 +20,7 @@ from absl.testing import absltest
 
 from compiler_opt.distributed.local import local_worker_manager
 from compiler_opt.rl import corpus
-from compiler_opt.es import blackbox_learner_test
+from compiler_opt.es import blackbox_test_utils
 from compiler_opt.es import blackbox_evaluator
 
 
@@ -29,7 +29,7 @@ class BlackboxEvaluatorTests(absltest.TestCase):
 
   def test_sampling_get_results(self):
     with local_worker_manager.LocalWorkerPoolManager(
-        blackbox_learner_test.ESWorker, count=3, arg='', kwarg='') as pool:
+        blackbox_test_utils.ESWorker, count=3, arg='', kwarg='') as pool:
       perturbations = [b'00', b'01', b'10']
       evaluator = blackbox_evaluator.SamplingBlackboxEvaluator(None, 5, 5, None)
       # pylint: disable=protected-access

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test facilities for Blackbox classes."""
+
+from typing import List
+
+import gin
+
+from compiler_opt.distributed import worker
+from compiler_opt.rl import corpus
+from compiler_opt.rl import policy_saver
+
+
+@gin.configurable
+class ESWorker(worker.Worker):
+  """Temporary placeholder worker.
+  Each time a worker is called, the function value
+  it will return increases."""
+
+  def __init__(self, arg, *, kwarg):
+    self._arg = arg
+    self._kwarg = kwarg
+    self.function_value = 0.0
+
+  def compile(self, policy: policy_saver.Policy,
+              samples: List[corpus.ModuleSpec]) -> float:
+    if policy and samples:
+      self.function_value += 1.0
+      return self.function_value
+    else:
+      return 0.0


### PR DESCRIPTION
This doesn't technically remove a circular dependency, but it does remove an awkward one.