### PR TITLE
Use multiprocessing.handle_test_main in buffered_scheduler_test

### DIFF
--- a/compiler_opt/distributed/buffered_scheduler_test.py
+++ b/compiler_opt/distributed/buffered_scheduler_test.py
@@ -22,6 +22,7 @@ from absl.testing import absltest
 from compiler_opt.distributed import worker
 from compiler_opt.distributed import buffered_scheduler
 from compiler_opt.distributed.local import local_worker_manager
+from tf_agents.system import system_multiprocessing as multiprocessing
 
 
 class BufferedSchedulerTest(absltest.TestCase):
@@ -144,4 +145,4 @@ class BufferedSchedulerTest(absltest.TestCase):
 
 
 if __name__ == '__main__':
-  absltest.main()
+  multiprocessing.handle_test_main(absltest.main)


### PR DESCRIPTION
This is necessary to enable the test to run internally and makes it consistent with other tests that call multiprocessing functionality under the hood.