### PR TITLE
Use actual corpus in es_trainer_lib

### DIFF
--- a/compiler_opt/es/es_trainer_lib.py
+++ b/compiler_opt/es/es_trainer_lib.py
@@ -115,7 +115,7 @@ def train(additional_compilation_flags=(),
   logging.info("Initial parameters: %s", initial_parameters)
 
   cps = corpus.Corpus(
-      location=_TRAIN_CORPORA.value,
+      data_path=_TRAIN_CORPORA.value,
       additional_flags=additional_compilation_flags,
       delete_flags=delete_compilation_flags,
       replace_flags=replace_compilation_flags)

--- a/compiler_opt/es/es_trainer_lib.py
+++ b/compiler_opt/es/es_trainer_lib.py
@@ -70,6 +70,7 @@ _TRAIN_CORPORA = flags.DEFINE_string("train_corpora", "",
 @gin.configurable
 def train(additional_compilation_flags=(),
           delete_compilation_flags=(),
+          replace_compilation_flags=(),
           worker_class=None):
   """Train with ES."""
 
@@ -113,11 +114,11 @@ def train(additional_compilation_flags=(),
   logging.info("Parameter dimension: %s", initial_parameters.shape)
   logging.info("Initial parameters: %s", initial_parameters)
 
-  cps = corpus.create_corpus_for_testing(
+  cps = corpus.Corpus(
       location=_TRAIN_CORPORA.value,
-      elements=[corpus.ModuleSpec(name="smth", size=1)],
       additional_flags=additional_compilation_flags,
-      delete_flags=delete_compilation_flags)
+      delete_flags=delete_compilation_flags,
+      replace_flags=replace_compilation_flags)
 
   # Construct policy saver
   saved_policy = policy_utils.create_actor_policy(greedy=True)


### PR DESCRIPTION
This patch makes es_trainer_lib load an actual corpus from the provided path rather than creating a dummy test corpus. Additionally, we also begin passing the replace_compilation_flags parameter, which is necessary for rewriting the paths to PGO profiles.