### PR TITLE
Change main docker container to python3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /ml-compiler-opt
 COPY . .


### PR DESCRIPTION
In preparation for deprecating support for python 3.8 and 3.9, bump the main docker container to python 3.10.