### PR TITLE
Drop CI for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           if [ -z $ACT ]
           then
-            _ver="['3.8', '3.9', '3.10']"
+            _ver="['3.10']"
             _cache="1"
           else
             # 3.8 instead of '3.8' to make github act work.


### PR DESCRIPTION
Now that all the users of mlcompileropt are containerized, we can drop support for Python 3.8 and 3.9.