### PR TITLE
Add Python 3.11 to CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,11 @@ jobs:
         run: |
           if [ -z $ACT ]
           then
-            _ver="['3.10']"
+            _ver="['3.10','3.11']"
             _cache="1"
           else
             # 3.10 instead of '3.10' to make github act work.
-            _ver="[3.10]"
+            _ver="[3.10,3.11]"
             _cache="0"
           fi
           echo "version_matrix=$_ver" >> $GITHUB_OUTPUT

--- a/compiler_opt/rl/distributed/agent.py
+++ b/compiler_opt/rl/distributed/agent.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """PPO agent definition and utility functions."""
 
-from typing import Optional, Text, Tuple
+from typing import Optional, Tuple
 
 from absl import logging
 
@@ -67,7 +67,7 @@ class MLGOPPOAgent(ppo_agent.PPOAgent):
                train_step_counter: Optional[tf.Variable] = None,
                aggregate_losses_across_replicas=False,
                loss_scaling_factor=1.,
-               name: Optional[Text] = 'PPOClipAgent'):
+               name: Optional[str] = 'PPOClipAgent'):
     """Creates a PPO Agent implementing the clipped probability ratios.
 
     Args:

--- a/compiler_opt/rl/distributed/learner.py
+++ b/compiler_opt/rl/distributed/learner.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Utility to create MLGO policy learner."""
 
-from typing import Callable, List, Optional, Text, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from absl import logging
 
@@ -47,7 +47,7 @@ class MLGOPPOLearner(object):
   """
 
   def __init__(self,
-               root_dir: Text,
+               root_dir: str,
                train_step: tf.Variable,
                model_id: tf.Variable,
                agent: ppo_agent.PPOAgent,

--- a/compiler_opt/rl/regalloc/regalloc_network.py
+++ b/compiler_opt/rl/regalloc/regalloc_network.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Actor network for Register Allocation."""
 
-from typing import Optional, Sequence, Callable, Text, Any
+from typing import Optional, Sequence, Callable, Any
 
 import gin
 import tensorflow as tf
@@ -78,7 +78,7 @@ class RegAllocNetwork(network.DistributionNetwork):
       kernel_initializer: Optional[tf.keras.initializers.Initializer] = None,
       batch_squash: bool = True,
       dtype: tf.DType = tf.float32,
-      name: Text = 'RegAllocNetwork'):
+      name: str = 'RegAllocNetwork'):
     """Creates an instance of `RegAllocNetwork`.
 
     Args:


### PR DESCRIPTION
Python 3.11 is the version used internally at Google, and testing a more recent version shouldn't hurt.