### PR TITLE
Ignore .pytype directory for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,7 @@ ignore=third_party
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=.pytype
 
 # Pickle collected data for later comparisons.
 persistent=no


### PR DESCRIPTION
After upgrading pytype, it now writes a bunch of .pyi files into the .pytype directory. yapf and pylint pick these directories up and report a ton of issues that are completely meaningless. This patch makes it so that pylint ignores any files within .pytype. yapf does not have any option in the config to ignore files, so just blanket running yapf . -ir or specifying individual files is still necessary, but I think that should be less interruptive. This is purely a developer workflow improvement.