### PR TITLE
Move get_rewards to BlackboxEvaluator base class

### DIFF
--- a/compiler_opt/es/blackbox_evaluator.py
+++ b/compiler_opt/es/blackbox_evaluator.py
@@ -45,10 +45,18 @@ class BlackboxEvaluator(metaclass=abc.ABCMeta):
   def set_baseline(self) -> None:
     raise NotImplementedError()
 
-  @abc.abstractmethod
   def get_rewards(
       self, results: List[concurrent.futures.Future]) -> List[Optional[float]]:
-    raise NotImplementedError()
+    rewards = [None] * len(results)
+
+    for i in range(len(results)):
+      if not results[i].exception():
+        rewards[i] = results[i].result()
+      else:
+        logging.info('Error retrieving result from future: %s',
+                     str(results[i].exception()))
+
+    return rewards
 
 
 @gin.configurable
@@ -95,16 +103,3 @@ class SamplingBlackboxEvaluator(BlackboxEvaluator):
 
   def set_baseline(self) -> None:
     pass
-
-  def get_rewards(
-      self, results: List[concurrent.futures.Future]) -> List[Optional[float]]:
-    rewards = [None] * len(results)
-
-    for i in range(len(results)):
-      if not results[i].exception():
-        rewards[i] = results[i].result()
-      else:
-        logging.info('Error retrieving result from future: %s',
-                     str(results[i].exception()))
-
-    return rewards

--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -41,7 +41,7 @@ class BlackboxEvaluatorTests(absltest.TestCase):
       self.assertSequenceAlmostEqual([result.result() for result in results],
                                      [1.0, 1.0, 1.0])
 
-  def test_sampling_get_rewards(self):
+  def test_get_rewards(self):
     f1 = concurrent.futures.Future()
     f1.set_exception(None)
     f2 = concurrent.futures.Future()


### PR DESCRIPTION
Previously this function was implemented by subclasses. Move it to the
base class given everything we have planned so far
(TraceBlackboxEvaluator) will use the same implementation.
