### PR TITLE
misc: ruff rules E741 and YTT204

### DIFF
--- a/compiler_opt/distributed/worker.py
+++ b/compiler_opt/distributed/worker.py
@@ -105,7 +105,7 @@ def get_full_worker_args(worker_class: 'type[Worker]', **current_kwargs):
     # it's not a requirement that it were. Tests, for instance, don't use gin.
     pass
   # Issue #38
-  if sys.version_info.minor >= 9:
+  if sys.version_info >= (3, 9):
     return current_kwargs | gin_config
   else:
     return {**current_kwargs, **gin_config}

--- a/compiler_opt/rl/data_collector_test.py
+++ b/compiler_opt/rl/data_collector_test.py
@@ -30,7 +30,7 @@ class DataCollectorTest(absltest.TestCase):
     monitor_dict = data_collector.build_distribution_monitor(data)
     reference_dict = {'mean': 2, 'p_0.1': 1}
     # Issue #38
-    if sys.version_info.minor >= 9:
+    if sys.version_info >= (3, 9):
       self.assertEqual(monitor_dict, monitor_dict | reference_dict)
     else:
       self.assertEqual(monitor_dict, {**monitor_dict, **reference_dict})

--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
@@ -338,8 +338,8 @@ class ImitationLearningTrainer:
 
   def _get_loss_fn(self, y_true, y_pred, labels, weights_arr):
     weights = tf.ones_like(y_true, dtype=tf.float64)
-    for l, wa in zip(labels, weights_arr):
-      w = self._create_weights(l, wa)
+    for label, wa in zip(labels, weights_arr):
+      w = self._create_weights(label, wa)
       w = tf.reshape(w, [-1, 1])
       weights = tf.math.multiply(w, weights)
     bce = tf.keras.losses.BinaryCrossentropy(from_logits=False)

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -181,7 +181,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
           }
       }
       # Issue #38
-      if sys.version_info.minor >= 9:
+      if sys.version_info >= (3, 9):
         self.assertEqual(monitor_dict,
                          monitor_dict | expected_monitor_dict_subset)
       else:
@@ -201,7 +201,7 @@ class LocalDataCollectorTest(tf.test.TestCase):
           }
       }
       # Issue #38
-      if sys.version_info.minor >= 9:
+      if sys.version_info >= (3, 9):
         self.assertEqual(monitor_dict,
                          monitor_dict | expected_monitor_dict_subset)
       else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 103
-lint.select = [ "C40", "C9", "E", "F", "PERF", "W" ]
-lint.ignore = [ "E722", "E731", "E741", "F401", "PERF203" ]
+lint.select = [ "C40", "C9", "E", "F", "PERF", "W", "YTT" ]
+lint.ignore = [ "E722", "E731", "F401", "PERF203" ]
 lint.mccabe.max-complexity = 18
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
% [`ruff rule YTT204`](https://docs.astral.sh/ruff/rules/sys-version-info-minor-cmp-int) `sys-version-info-minor-cmp-int`

% [`ruff rule E741`](https://docs.astral.sh/ruff/rules/ambiguous-variable-name)
# ambiguous-variable-name (E741)

Derived from the **pycodestyle** linter.

## What it does
Checks for the use of the characters 'l', 'O', or 'I' as variable names.

Note: This rule is automatically disabled for all stub files
(files with `.pyi` extensions). The rule has little relevance for authors
of stubs: a well-written stub should aim to faithfully represent the
interface of the equivalent .py file as it exists at runtime, including any
ambiguously named variables in the runtime module.

## Why is this bad?
In some fonts, these characters are indistinguishable from the
numerals one and zero. When tempted to use 'l', use 'L' instead.

## Example
```python
l = 0
O = 123
I = 42
```

Use instead:
```python
L = 0
o = 123
i = 42
```
