### PR TITLE
Remove greedy flag from es_trainer_lib

### DIFF
--- a/compiler_opt/es/es_trainer_lib.py
+++ b/compiler_opt/es/es_trainer_lib.py
@@ -46,12 +46,6 @@ _GRADIENT_ASCENT_OPTIMIZER_TYPE = flags.DEFINE_string(
     "gradient_ascent_optimizer_type", None,
     "Gradient ascent optimization algorithm: 'momentum' or 'adam'")
 flags.mark_flag_as_required("gradient_ascent_optimizer_type")
-_GREEDY = flags.DEFINE_bool(
-    "greedy",
-    None,
-    "Whether to construct a greedy policy (argmax). \
-      If False, a sampling-based policy will be used.",
-    required=True)
 _MOMENTUM = flags.DEFINE_float(
     "momentum", 0.0, "Momentum for momentum gradient ascent optimizer.")
 _OUTPUT_PATH = flags.DEFINE_string("output_path", "",
@@ -82,7 +76,7 @@ def train(additional_compilation_flags=(),
     tf.io.gfile.makedirs(_OUTPUT_PATH.value)
 
   # Construct the policy and upload it
-  policy = policy_utils.create_actor_policy(greedy=_GREEDY.value)
+  policy = policy_utils.create_actor_policy()
   saver = policy_saver.PolicySaver({POLICY_NAME: policy})
 
   # Save the policy
@@ -121,7 +115,7 @@ def train(additional_compilation_flags=(),
       replace_flags=replace_compilation_flags)
 
   # Construct policy saver
-  saved_policy = policy_utils.create_actor_policy(greedy=True)
+  saved_policy = policy_utils.create_actor_policy()
   policy_saver_function = functools.partial(
       policy_utils.save_policy,
       policy=saved_policy,


### PR DESCRIPTION
This is already configurable through gin in policy_utils, is not consistently
used within es_trainer_lib, and overall just adds unnecessary complexity.
