### PR TITLE
[BC] Compiler timeout

### DIFF
--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
@@ -180,8 +180,8 @@ class TrainingWeights:
         bucket_loss += np.maximum(prof[SequenceExampleFeatureNames.regret], 0)
       losses_per_bucket.append(bucket_loss)
     logging.info('Losses per bucket: %s', losses_per_bucket)
-    losses_per_bucket_normalized = losses_per_bucket / np.max(
-        np.abs(losses_per_bucket))
+    losses_per_bucket_normalized = losses_per_bucket / (
+        np.max(np.abs(losses_per_bucket)) + 1e-6)
     probs_t = self._get_exp_gradient_step(losses_per_bucket_normalized, 1.0)
     self._round += 1
     self._probs = (self._probs * (self._round - 1) + probs_t) / self._round
@@ -385,7 +385,7 @@ class ImitationLearningTrainer:
     """Train the model for number of the specified number of epochs."""
     dataset = self.load_dataset(filepaths)
     logging.info('Datasets loaded from %s', str(filepaths))
-    input_shape = dataset.element_spec[0].shape[-1]
+    input_shape = int(dataset.element_spec[0].shape[-1])
     self._initialize_model(input_shape=input_shape)
     self._initialize_metrics()
     for _ in range(self._epochs):

--- a/compiler_opt/rl/inlining/gin_configs/common.gin
+++ b/compiler_opt/rl/inlining/gin_configs/common.gin
@@ -15,7 +15,7 @@ env.InliningForSizeTask.llvm_size_path=%llvm_size_path
 env.get_inlining_env.clang_path=%clang_path
 
 problem_config.flags_to_add.add_flags=()
-problem_config.flags_to_delete.delete_flags=('-split-dwarf-file','-split-dwarf-output',)
+problem_config.flags_to_delete.delete_flags=('-split-dwarf-file','-split-dwarf-output','--crel','-fskip-odr-check-in-gmf','--warning-suppression-mappings')
 # For AFDO profile reinjection set:
 # problem_config.flags_to_replace.replace_flags={'-fprofile-sample-use':'/path/to/gwp.afdo','-fprofile-remapping-file':'/path/to/prof_remap.txt'}
 problem_config.flags_to_replace.replace_flags={}

--- a/compiler_opt/rl/inlining/gin_configs/imitation_learning.gin
+++ b/compiler_opt/rl/inlining/gin_configs/imitation_learning.gin
@@ -7,7 +7,7 @@ env.InliningForSizeTask.llvm_size_path=''
 
 generate_bc_trajectories_lib.ModuleWorker.clang_path=''
 generate_bc_trajectories_lib.ModuleWorker.mlgo_task_type=@env.InliningForSizeTask
-generate_bc_trajectories_lib.ModuleWorker.policy_paths=['']
+generate_bc_trajectories_lib.ModuleWorker.policy_paths=[]
 generate_bc_trajectories_lib.ModuleWorker.exploration_policy_paths=[]
 generate_bc_trajectories_lib.ModuleWorker.explore_on_features=None
 generate_bc_trajectories_lib.ModuleWorker.partitions=[
@@ -15,14 +15,15 @@ generate_bc_trajectories_lib.ModuleWorker.partitions=[
     2467.0, 3344.0, 4545.0, 6459.0, 9845.0, 17953.0, 29430.5, 85533.5,
     124361.0]
 generate_bc_trajectories_lib.ModuleWorker.reward_key='default'
+# time in sec after which the clang processes time out
+generate_bc_trajectories_lib.ModuleWorker.timeout=300.0
 
 generate_bc_trajectories_lib.gen_trajectories.data_path=''
-generate_bc_trajectories_lib.gen_trajectories.delete_flags=('-split-dwarf-file', '-split-dwarf-output')
+generate_bc_trajectories_lib.gen_trajectories.delete_flags=('-split-dwarf-file', '-split-dwarf-output','--crel','-fskip-odr-check-in-gmf','--warning-suppression-mappings')
 generate_bc_trajectories_lib.gen_trajectories.output_file_name=''
 generate_bc_trajectories_lib.gen_trajectories.output_path=''
 generate_bc_trajectories_lib.gen_trajectories.mlgo_task_type=@imitation_learning_config.get_task_type()
 generate_bc_trajectories_lib.gen_trajectories.obs_action_spec=@imitation_learning_config.get_inlining_signature_spec()
 generate_bc_trajectories_lib.gen_trajectories.num_workers=1
-generate_bc_trajectories_lib.gen_trajectories.num_output_files=1
+generate_bc_trajectories_lib.gen_trajectories.num_output_files=2
 generate_bc_trajectories_lib.gen_trajectories.profiling_file_path=''
-generate_bc_trajectories_lib.gen_trajectories.worker_wait_sec=100

--- a/compiler_opt/rl/inlining/imitation_learning_config.py
+++ b/compiler_opt/rl/inlining/imitation_learning_config.py
@@ -80,6 +80,7 @@ def get_input_signature():
 @gin.register
 def get_task_type() -> Type[env.InliningForSizeTask]:
   """Returns the task type for the trajectory collection."""
+  #TODO(@tvmarino): make the reward_key match that in ModuleWorker
   return env.InliningForSizeTask
 
 

--- a/compiler_opt/rl/log_reader.py
+++ b/compiler_opt/rl/log_reader.py
@@ -182,13 +182,19 @@ def _enumerate_log_from_stream(
       continue
     observation_id = int(event['observation'])
     features = [_read_tensor(f, ts) for ts in tensor_specs]
-    f.readline()
+    new_line_read = f.readline()
+    if not '\n'.encode('utf-8') == new_line_read:
+      raise AssertionError(('Expected newline in readline,'
+                            f'Received {new_line_read.decode("utf-8")}'))
     score = None
     if score_spec is not None:
       score_header = json.loads(f.readline())
       assert int(score_header['outcome']) == observation_id
       score = _read_tensor(f, score_spec)
-      f.readline()
+      new_line_read = f.readline()
+    if not '\n'.encode('utf-8') == new_line_read:
+      raise AssertionError(('Expected newline in readline,'
+                            f'Received {new_line_read.decode("utf-8")}'))
     yield ObservationRecord(
         context=context,
         observation_id=observation_id,


### PR DESCRIPTION
Updates to ```generate_bc_trajectories_lib```, ```env``` and ```log_reader``` to include
timing out the clang processes. Updates to ```weighted_bc_trainer_lib``` to
determine the input shape for the policy network.