### PR TITLE
Remove deprecated Python utf8 encoding declaration

### DIFF
--- a/check-license.sh
+++ b/check-license.sh
@@ -33,7 +33,7 @@ check_license () {
 
 for fname in `find . -name "*.py"`;
 do
-  check_license $fname "$(cat license-header.txt)" 15
+  check_license $fname "$(tail -13 license-header.txt)" 14
 done
 
 for fname in `find . -name "*.sh"`;

--- a/compiler_opt/__init__.py
+++ b/compiler_opt/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/__init__.py
+++ b/compiler_opt/benchmark/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmark_chromium.py
+++ b/compiler_opt/benchmark/benchmark_chromium.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmark_llvm_test_suite.py
+++ b/compiler_opt/benchmark/benchmark_llvm_test_suite.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmark_report.py
+++ b/compiler_opt/benchmark/benchmark_report.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmark_report_converter.py
+++ b/compiler_opt/benchmark/benchmark_report_converter.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmark_report_test.py
+++ b/compiler_opt/benchmark/benchmark_report_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/benchmarking_utils.py
+++ b/compiler_opt/benchmark/benchmarking_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/filter_tests.py
+++ b/compiler_opt/benchmark/filter_tests.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/gtest_executable_utils.py
+++ b/compiler_opt/benchmark/gtest_executable_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/benchmark/list_gtests.py
+++ b/compiler_opt/benchmark/list_gtests.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/__init__.py
+++ b/compiler_opt/distributed/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/buffered_scheduler.py
+++ b/compiler_opt/distributed/buffered_scheduler.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/buffered_scheduler_test.py
+++ b/compiler_opt/distributed/buffered_scheduler_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/local/__init__.py
+++ b/compiler_opt/distributed/local/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/local/local_worker_manager.py
+++ b/compiler_opt/distributed/local/local_worker_manager.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/local/local_worker_manager_test.py
+++ b/compiler_opt/distributed/local/local_worker_manager_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/worker.py
+++ b/compiler_opt/distributed/worker.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/distributed/worker_test.py
+++ b/compiler_opt/distributed/worker_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/__init__.py
+++ b/compiler_opt/es/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_evaluator.py
+++ b/compiler_opt/es/blackbox_evaluator.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_optimizers.py
+++ b/compiler_opt/es/blackbox_optimizers.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_optimizers_test.py
+++ b/compiler_opt/es/blackbox_optimizers_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/es_trainer.py
+++ b/compiler_opt/es/es_trainer.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/es_trainer_lib.py
+++ b/compiler_opt/es/es_trainer_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/gradient_ascent_optimization_algorithms.py
+++ b/compiler_opt/es/gradient_ascent_optimization_algorithms.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/gradient_ascent_optimization_algorithms_test.py
+++ b/compiler_opt/es/gradient_ascent_optimization_algorithms_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/policy_utils.py
+++ b/compiler_opt/es/policy_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/policy_utils_test.py
+++ b/compiler_opt/es/policy_utils_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/regalloc_trace/__init__.py
+++ b/compiler_opt/es/regalloc_trace/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/regalloc_trace/regalloc_trace_worker.py
+++ b/compiler_opt/es/regalloc_trace/regalloc_trace_worker.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/es/regalloc_trace/regalloc_trace_worker_test.py
+++ b/compiler_opt/es/regalloc_trace/regalloc_trace_worker_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/__init__.py
+++ b/compiler_opt/rl/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/agent_config.py
+++ b/compiler_opt/rl/agent_config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/agent_config_test.py
+++ b/compiler_opt/rl/agent_config_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/best_trajectory.py
+++ b/compiler_opt/rl/best_trajectory.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/best_trajectory_test.py
+++ b/compiler_opt/rl/best_trajectory_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/constant.py
+++ b/compiler_opt/rl/constant.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/constant_value_network.py
+++ b/compiler_opt/rl/constant_value_network.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/constant_value_network_test.py
+++ b/compiler_opt/rl/constant_value_network_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_collector.py
+++ b/compiler_opt/rl/data_collector.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_collector_test.py
+++ b/compiler_opt/rl/data_collector_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_reader.py
+++ b/compiler_opt/rl/data_reader.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/data_reader_test.py
+++ b/compiler_opt/rl/data_reader_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/__init__.py
+++ b/compiler_opt/rl/distributed/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/agent.py
+++ b/compiler_opt/rl/distributed/agent.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/learner.py
+++ b/compiler_opt/rl/distributed/learner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_collect.py
+++ b/compiler_opt/rl/distributed/ppo_collect.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_collect_lib.py
+++ b/compiler_opt/rl/distributed/ppo_collect_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_eval.py
+++ b/compiler_opt/rl/distributed/ppo_eval.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_eval_lib.py
+++ b/compiler_opt/rl/distributed/ppo_eval_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_reverb_server.py
+++ b/compiler_opt/rl/distributed/ppo_reverb_server.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_reverb_server_lib.py
+++ b/compiler_opt/rl/distributed/ppo_reverb_server_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_train.py
+++ b/compiler_opt/rl/distributed/ppo_train.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/distributed/ppo_train_lib.py
+++ b/compiler_opt/rl/distributed/ppo_train_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/env.py
+++ b/compiler_opt/rl/env.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/env_test.py
+++ b/compiler_opt/rl/env_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/feature_ops.py
+++ b/compiler_opt/rl/feature_ops.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/feature_ops_test.py
+++ b/compiler_opt/rl/feature_ops_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/gin_external_configurables.py
+++ b/compiler_opt/rl/gin_external_configurables.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/__init__.py
+++ b/compiler_opt/rl/imitation_learning/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/generate_bc_trajectories.py
+++ b/compiler_opt/rl/imitation_learning/generate_bc_trajectories.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/generate_bc_trajectories_lib.py
+++ b/compiler_opt/rl/imitation_learning/generate_bc_trajectories_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/generate_bc_trajectories_test.py
+++ b/compiler_opt/rl/imitation_learning/generate_bc_trajectories_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer_test.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/__init__.py
+++ b/compiler_opt/rl/inlining/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/config.py
+++ b/compiler_opt/rl/inlining/config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/env.py
+++ b/compiler_opt/rl/inlining/env.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/imitation_learning_config.py
+++ b/compiler_opt/rl/inlining/imitation_learning_config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/imitation_learning_runner.py
+++ b/compiler_opt/rl/inlining/imitation_learning_runner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/local_data_collector.py
+++ b/compiler_opt/rl/local_data_collector.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/log_reader.py
+++ b/compiler_opt/rl/log_reader.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/log_reader_test.py
+++ b/compiler_opt/rl/log_reader_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/policy_saver.py
+++ b/compiler_opt/rl/policy_saver.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/policy_saver_test.py
+++ b/compiler_opt/rl/policy_saver_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/problem_configuration.py
+++ b/compiler_opt/rl/problem_configuration.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/random_net_distillation.py
+++ b/compiler_opt/rl/random_net_distillation.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/random_net_distillation_test.py
+++ b/compiler_opt/rl/random_net_distillation_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc/__init__.py
+++ b/compiler_opt/rl/regalloc/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc/config.py
+++ b/compiler_opt/rl/regalloc/config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc/regalloc_network.py
+++ b/compiler_opt/rl/regalloc/regalloc_network.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc/regalloc_network_test.py
+++ b/compiler_opt/rl/regalloc/regalloc_network_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc_priority/__init__.py
+++ b/compiler_opt/rl/regalloc_priority/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc_priority/config.py
+++ b/compiler_opt/rl/regalloc_priority/config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/regalloc_priority/regalloc_priority_runner.py
+++ b/compiler_opt/rl/regalloc_priority/regalloc_priority_runner.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/registry.py
+++ b/compiler_opt/rl/registry.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/train_bc.py
+++ b/compiler_opt/rl/train_bc.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/train_locally.py
+++ b/compiler_opt/rl/train_locally.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/trainer.py
+++ b/compiler_opt/rl/trainer.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/rl/trainer_test.py
+++ b/compiler_opt/rl/trainer_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/testing/__init__.py
+++ b/compiler_opt/testing/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/testing/model_test_utils.py
+++ b/compiler_opt/testing/model_test_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/__init__.py
+++ b/compiler_opt/tools/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/combine_tfa_policies.py
+++ b/compiler_opt/tools/combine_tfa_policies.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/combine_tfa_policies_lib.py
+++ b/compiler_opt/tools/combine_tfa_policies_lib.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/combine_tfa_policies_lib_test.py
+++ b/compiler_opt/tools/combine_tfa_policies_lib_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/feature_importance.py
+++ b/compiler_opt/tools/feature_importance.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/feature_importance_graphs.py
+++ b/compiler_opt/tools/feature_importance_graphs.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/feature_importance_utils.py
+++ b/compiler_opt/tools/feature_importance_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/feature_importance_utils_test.py
+++ b/compiler_opt/tools/feature_importance_utils_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/generate_test_model.py
+++ b/compiler_opt/tools/generate_test_model.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/generate_test_model_test.py
+++ b/compiler_opt/tools/generate_test_model_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/generate_vocab.py
+++ b/compiler_opt/tools/generate_vocab.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/tools/merge_best_trajectory.py
+++ b/compiler_opt/tools/merge_best_trajectory.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compiler_opt/type_map.py
+++ b/compiler_opt/type_map.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
% [`ruff rule UP009`](https://docs.astral.sh/ruff/rules/utf8-encoding-declaration)
# utf8-encoding-declaration (UP009)

Derived from the **pyupgrade** linter.

Fix is always available.

## What it does
Checks for unnecessary UTF-8 encoding declarations.

## Why is this bad?
[PEP 3120] makes UTF-8 the default encoding, so a UTF-8 encoding
declaration is unnecessary.

## Example
```python
# -*- coding: utf-8 -*-
print("Hello, world!")
```

Use instead:
```python
print("Hello, world!")
```

[PEP 3120]: https://peps.python.org/pep-3120/
