### PR TITLE
Fix local_worker_manager_test when run from command line

### DIFF
--- a/compiler_opt/distributed/local/local_worker_manager_test.py
+++ b/compiler_opt/distributed/local/local_worker_manager_test.py
@@ -24,7 +24,7 @@ from compiler_opt.distributed.worker import Worker
 from compiler_opt.distributed.local import local_worker_manager
 from tf_agents.system import system_multiprocessing as multiprocessing
 
-_TEST_FLAG = flags.DEFINE_integer(
+flags.DEFINE_integer(
     'test_only_flag', default=1, help='A flag used by some tests.')
 
 
@@ -74,7 +74,7 @@ class JobSlow(Worker):
 class JobGetFlags(Worker):
 
   def method(self):
-    return {'argv': sys.argv, 'the_flag': _TEST_FLAG.value}
+    return {'argv': sys.argv, 'the_flag': flags.FLAGS.test_only_flag}
 
 
 class LocalWorkerManagerTest(absltest.TestCase):


### PR DESCRIPTION
When run in pytest, the test flag for `test_flag_parsing` isn't defined in the main module, so cloudpickle will serialize it by reference (good). That changes when we run the test from the command line, as `FlagValue` isn't serializable.