### PR TITLE
Ignore ruff C408

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 103
 lint.select = [ "C40", "C9", "E", "F", "PERF", "UP", "W", "YTT" ]
-lint.ignore = [ "E722", "E731", "F401", "PERF203" ]
+lint.ignore = [ "E722", "E731", "F401", "PERF203", "C408" ]
 lint.mccabe.max-complexity = 18
 target-version = "py310"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [tool.ruff]
 line-length = 103
 lint.select = [ "C40", "C9", "E", "F", "PERF", "UP", "W", "YTT" ]
-lint.ignore = [ "E722", "E731", "F401", "PERF203", "C408" ]
+lint.ignore = [ "E722", "E731", "F401", "PERF203" ]
 lint.mccabe.max-complexity = 18
 target-version = "py310"
+
+[tool.ruff.lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true
 
 [tool.pytest.ini_options]
 # DO always create a tracking issue when allow-listing warnings


### PR DESCRIPTION
We make use of kwargs quite a bit, and it's sometimes necessary to pass then through, e.g. to workers from the worker manager. It looks (aesthetically, at least) cleaner to pass as `key=value` rather than `"key":value`, also, we can avoid silly typos like `"k ey"`.