### PR TITLE
Use standard pickle, and make pickler an option

### DIFF
--- a/compiler_opt/distributed/buffered_scheduler_test.py
+++ b/compiler_opt/distributed/buffered_scheduler_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Test for buffered_scheduler."""
 
+import cloudpickle
 import concurrent.futures
 import threading
 import time
@@ -35,7 +36,7 @@ class BufferedSchedulerTest(absltest.TestCase):
         return n + 1
 
     with local_worker_manager.LocalWorkerPoolManager(
-        WaitingWorker, count=2) as pool:
+        WaitingWorker, count=2, pickle_func=cloudpickle.dumps) as pool:
       _, futures = buffered_scheduler.schedule_on_worker_pool(
           lambda w, v: w.wait_seconds(v), range(4), pool)
       not_done = futures
@@ -54,7 +55,7 @@ class BufferedSchedulerTest(absltest.TestCase):
         return the_value * the_value * extra_factor
 
     with local_worker_manager.LocalWorkerPoolManager(
-        TheWorker, count=2) as pool:
+        TheWorker, count=2, pickle_func=cloudpickle.dumps) as pool:
       workers, futures = buffered_scheduler.schedule_on_worker_pool(
           lambda w, v: w.square(v), range(10), pool)
       self.assertLen(workers, 2)

--- a/compiler_opt/distributed/local/local_worker_manager_test.py
+++ b/compiler_opt/distributed/local/local_worker_manager_test.py
@@ -24,7 +24,7 @@ from compiler_opt.distributed.worker import Worker
 from compiler_opt.distributed.local import local_worker_manager
 from tf_agents.system import system_multiprocessing as multiprocessing
 
-flags.DEFINE_integer(
+_TEST_FLAG = flags.DEFINE_integer(
     'test_only_flag', default=1, help='A flag used by some tests.')
 
 
@@ -74,7 +74,7 @@ class JobSlow(Worker):
 class JobGetFlags(Worker):
 
   def method(self):
-    return {'argv': sys.argv, 'the_flag': flags.FLAGS.test_only_flag}
+    return {'argv': sys.argv, 'the_flag': _TEST_FLAG.value}
 
 
 class LocalWorkerManagerTest(absltest.TestCase):

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -15,6 +15,7 @@
 
 import os
 from absl.testing import absltest
+import cloudpickle
 import gin
 import tempfile
 import numpy as np
@@ -148,6 +149,7 @@ class BlackboxLearnerTests(absltest.TestCase):
     with local_worker_manager.LocalWorkerPoolManager(
         blackbox_test_utils.ESWorker,
         count=3,
+        pickle_func=cloudpickle.dumps,
         worker_args=('',),
         worker_kwargs=dict(kwarg='')) as pool:
       self._learner.run_step(pool)  # pylint: disable=protected-access


### PR DESCRIPTION
We used cloudpickle to make it easy to author tests where the
test worker is defined in the test function. The problem is that
cloudpickle will also try to serialize by value classes defined in the
`__main__` module, which leads to serialization problems when e.g. the worker class
references in its members unpickleable things.

Also, revert #452 as it is addressed by this change.
