### PR TITLE
Disable pytype pyi-error globally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,9 @@ jobs:
         task: [Typecheck, Lint, Ruff, Yapf, Test]
         include:
           - task: Typecheck
-            cmd: pytype -j auto .
+            # We disable pyi-error due to https://github.com/google/pytype/issues/764
+            # and other related issues with tensorflow imports.
+            cmd: pytype -j auto --disable=pyi-error .
           - task: Lint
             cmd: pylint --rcfile .pylintrc --recursive yes .
           - task: Ruff

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -31,10 +31,6 @@ from compiler_opt.rl import corpus
 from compiler_opt.rl import policy_saver
 from compiler_opt.es import blackbox_evaluator  # pylint: disable=unused-import
 
-# Pytype cannot pick up the pyi file for tensorflow.summary. Disable the error
-# here as these errors are false positives.
-# pytype: disable=pyi-error
-
 # If less than 40% of requests succeed, skip the step.
 _SKIP_STEP_SUCCESS_RATIO = 0.4
 

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -23,8 +23,7 @@ from unittest import mock
 from absl import flags
 import tensorflow as tf
 
-# This is https://github.com/google/pytype/issues/764
-from google.protobuf import text_format  # pytype: disable=pyi-error
+from google.protobuf import text_format
 
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import constant

--- a/compiler_opt/rl/imitation_learning/generate_bc_trajectories_test.py
+++ b/compiler_opt/rl/imitation_learning/generate_bc_trajectories_test.py
@@ -27,7 +27,7 @@ from tf_agents.trajectories import policy_step
 from tf_agents.trajectories import time_step
 from tf_agents.system import system_multiprocessing as multiprocessing
 
-from google.protobuf import text_format  # pytype: disable=pyi-error
+from google.protobuf import text_format
 
 from compiler_opt.rl.imitation_learning import generate_bc_trajectories_lib
 from compiler_opt.rl import env

--- a/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
+++ b/compiler_opt/rl/imitation_learning/weighted_bc_trainer_lib.py
@@ -43,10 +43,6 @@ _QUANTILE_MAP_PATH = flags.DEFINE_string(
     ('Directory containing the quantile map for normalizing features'
      'in feature_ops.build_quantile_map.'))
 
-# Pytype cannot pick up the pyi file for tensorflow.summary. Disable the error
-# here as these errors are false positives.
-# pytype: disable=pyi-error
-
 
 @gin.configurable
 class TrainingWeights:

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -20,8 +20,7 @@ import string
 import tensorflow as tf
 from tf_agents.system import system_multiprocessing as multiprocessing
 
-# This is https://github.com/google/pytype/issues/764
-from google.protobuf import text_format  # pytype: disable=pyi-error
+from google.protobuf import text_format
 from compiler_opt.distributed.local.local_worker_manager import LocalWorkerPoolManager
 from compiler_opt.rl import compilation_runner
 from compiler_opt.rl import corpus

--- a/compiler_opt/rl/log_reader_test.py
+++ b/compiler_opt/rl/log_reader_test.py
@@ -18,8 +18,7 @@ import enum
 import json
 from compiler_opt.rl import log_reader
 
-# This is https://github.com/google/pytype/issues/764
-from google.protobuf import text_format  # pytype: disable=pyi-error
+from google.protobuf import text_format
 from typing import BinaryIO
 
 import numpy as np

--- a/compiler_opt/rl/train_bc.py
+++ b/compiler_opt/rl/train_bc.py
@@ -20,10 +20,6 @@ from absl import flags
 from absl import logging
 import gin
 
-# Pytype cannot pick up the pyi file for tensorflow.summary. Disable the error
-# here as these errors are false positives.
-# pytype: disable=pyi-error
-
 # <Internal> Using XM - flags.  # pylint: disable=unused-import
 from compiler_opt.rl import agent_config
 from compiler_opt.rl import data_reader

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -22,8 +22,7 @@ from absl.testing import flagsaver
 import gin
 import tensorflow as tf
 
-# This is https://github.com/google/pytype/issues/764
-from google.protobuf import text_format  # pytype: disable=pyi-error
+from google.protobuf import text_format
 from compiler_opt.rl import compilation_runner
 from compiler_opt.tools import generate_default_trace
 


### PR DESCRIPTION
This patch disable pyi-error globally. We have a lot of manual disables for this error sprinkled throughout the codebase, to the point where we should just disable it globally given the noise that it causes.