### PR TITLE
Do not use global Numpy RNG

### DIFF
--- a/compiler_opt/rl/imitation_learning/generate_bc_trajectories_lib.py
+++ b/compiler_opt/rl/imitation_learning/generate_bc_trajectories_lib.py
@@ -367,6 +367,8 @@ class ModuleExplorer:
     self._explore_on_features = explore_on_features
     logging.info('Reward key in exploration worker: %s', self._reward_key)
 
+    self._rng = np.random.default_rng()
+
   def compile_module(
       self,
       policy: Callable[[time_step.TimeStep | None], np.ndarray],
@@ -545,7 +547,7 @@ class ModuleExplorer:
       distr_logits[replay_prefix[explore_step]] = -np.inf
       if all(-np.inf == logit for logit in distr_logits):
         break
-      replay_prefix[explore_step] = np.random.choice(
+      replay_prefix[explore_step] = self._rng.choice(
           range(distr_logits.shape[0]), p=scipy.special.softmax(distr_logits))
       base_policy = ExplorationWithPolicy(
           replay_prefix,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 103
-lint.select = [ "C40", "C9", "E", "F", "PERF", "UP", "W", "YTT" ]
+lint.select = [ "C40", "C9", "E", "F", "PERF", "UP", "W", "YTT", "NPY", "PD" ]
 lint.ignore = [ "E722", "E731", "F401", "PERF203" ]
 lint.mccabe.max-complexity = 18
 target-version = "py310"


### PR DESCRIPTION
This patch switches from using the default numpy RNG to explicitly using a specific RNG. This is reccomended by numpy and identified by Ruff's NPY002 rule. This keeps things out of global state which makes reasoning about RNG a bit easier, although the code is a bit more verbose.

Fixes #460.