### PR TITLE
Compute relative reward in trace blackbox evaluator

### DIFF
--- a/compiler_opt/es/blackbox_evaluator.py
+++ b/compiler_opt/es/blackbox_evaluator.py
@@ -23,6 +23,7 @@ from compiler_opt.distributed.worker import FixedWorkerPool
 from compiler_opt.rl import corpus
 from compiler_opt.es import blackbox_optimizers
 from compiler_opt.distributed import buffered_scheduler
+from compiler_opt.rl import compilation_runner
 
 
 class BlackboxEvaluator(metaclass=abc.ABCMeta):
@@ -159,3 +160,16 @@ class TraceBlackboxEvaluator(BlackboxEvaluator):
                        f' got {len(futures)}')
 
     self._baseline = futures[0].result()
+
+  def get_rewards(
+      self, results: list[concurrent.futures.Future]) -> list[float | None]:
+    rewards = []
+
+    for result in results:
+      if result.exception() is not None:
+        raise result.exception()
+
+      rewards.append(
+          compilation_runner._calculate_reward(result.result(), self._baseline))
+
+    return rewards

--- a/compiler_opt/es/blackbox_evaluator.py
+++ b/compiler_opt/es/blackbox_evaluator.py
@@ -169,8 +169,7 @@ class TraceBlackboxEvaluator(BlackboxEvaluator):
       if result.exception() is not None:
         raise result.exception()
 
-      # pylint: disable=protected-access
       rewards.append(
-          compilation_runner._calculate_reward(result.result(), self._baseline))
+          compilation_runner.calculate_reward(result.result(), self._baseline))
 
     return rewards

--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -83,3 +83,24 @@ class BlackboxEvaluatorTests(absltest.TestCase):
       evaluator.set_baseline(pool)
       # pylint: disable=protected-access
       self.assertAlmostEqual(evaluator._baseline, 10)
+
+  def test_trace_get_rewards(self):
+    f1 = concurrent.futures.Future()
+    f1.set_result(2)
+    f2 = concurrent.futures.Future()
+    f2.set_result(3)
+    results = [f1, f2]
+    test_corpus = corpus.create_corpus_for_testing(
+        location=self.create_tempdir().full_path,
+        elements=[corpus.ModuleSpec(name='name1', size=1)])
+    evaluator = blackbox_evaluator.TraceBlackboxEvaluator(
+        test_corpus, 5, "fake_bb_trace_path", "fake_function_index_path")
+
+    # pylint: disable=protected-access
+    evaluator._baseline = 2
+    rewards = evaluator.get_rewards(results)
+
+    # Only check for two decimal places as the reward calculation uses a
+    # reasonably large delta (0.01) when calculating the difference to
+    # prevent division by zero.
+    self.assertSequenceAlmostEqual(rewards, [0, -0.5], 2)

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -230,6 +230,9 @@ class BlackboxLearner:
   def get_model_weights(self) -> npt.NDArray[np.float32]:
     return self._model_weights
 
+  def set_baseline(self, pool: FixedWorkerPool) -> None:
+    self._evaluator.set_baseline(pool)
+
   def run_step(self, pool: FixedWorkerPool) -> None:
     """Run a single step of blackbox learning.
     This does not instantaneously return due to several I/O
@@ -245,12 +248,8 @@ class BlackboxLearner:
           p for p in initial_perturbations for p in (p, -p)
       ]
 
-    # TODO(boomanaiden154): This should be adding the perturbation to
-    # the existing model weights. That currently results in the model
-    # weights all being NaN, presumably due to rewards not being scaled for
-    # the regalloc_trace problem.
     perturbations_as_bytes = [
-        perturbation.astype(np.float32).tobytes()
+        (self._model_weights + perturbation).astype(np.float32).tobytes()
         for perturbation in initial_perturbations
     ]
 

--- a/compiler_opt/es/es_trainer_lib.py
+++ b/compiler_opt/es/es_trainer_lib.py
@@ -215,6 +215,7 @@ def train(additional_compilation_flags=(),
       worker_class,
       count=learner_config.total_num_perturbations,
       worker_kwargs=dict(gin_config=gin.operative_config_str())) as pool:
+    learner.set_baseline(pool)
     for _ in range(learner_config.total_steps):
       learner.run_step(pool)
 


### PR DESCRIPTION
This patch makes the trace blackbox evaluator return a relative reward rather
than the raw reward. This makes the rewards actually meaningful, and also
prevents overflowing calculatings in blackbox_optimizer which previously
made the new model weights NaN.
