### PR TITLE
Add option to generate_default_trace to output keys

### DIFF
--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -66,7 +66,7 @@ _GIN_BINDINGS = flags.DEFINE_multi_string(
     'Gin bindings to override the values set in the config files.')
 _KEYS_FILE = flags.DEFINE_string(
     'keys_file', None,
-    'THe path to the file to write out the keys encountered.')
+    'The path to the file to write out the keys encountered.')
 
 
 class FilteringWorker(worker.Worker):
@@ -207,8 +207,7 @@ def generate_trace(worker_manager_class: type[
 
   if _KEYS_FILE.value is not None:
     with open(_KEYS_FILE.value, 'w', encoding='utf-8') as keys_file:
-      for key in all_keys:
-        keys_file.write(f'{key}\n')
+      keys_file.write('\n'.join(str(key) for key in all_keys) + '\n')
 
 
 if __name__ == '__main__':

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -102,14 +102,16 @@ class FilteringWorker(worker.Worker):
               data.reward_stats, data.keys)
     new_reward_stats = {}
     new_sequence_examples = []
+    new_keys = []
     for k, sequence_example in zip(data.keys,
                                    data.serialized_sequence_examples):
       if not self._key_filter.match(k):
         continue
       new_reward_stats[k] = data.reward_stats[k]
       new_sequence_examples.append(sequence_example)
+      new_keys.append(k)
     return (loaded_module_spec.name, new_sequence_examples, new_reward_stats,
-            data.keys)
+            new_keys)
 
 
 def main(_):

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -83,7 +83,6 @@ class FilteringWorker(worker.Worker):
                runner_kwargs):
     self._policy_path = policy_path
     self._key_filter = re.compile(key_filter) if key_filter else None
-    print(runner_kwargs)
     self._runner = runner_type(**runner_kwargs)
     self._policy = policy_saver.Policy.from_filesystem(
         policy_path) if policy_path else None

--- a/compiler_opt/tools/generate_default_trace.py
+++ b/compiler_opt/tools/generate_default_trace.py
@@ -205,7 +205,7 @@ def generate_trace(worker_manager_class: type[
         'written')
 
   if _KEYS_FILE.value is not None:
-    with open(_KEYS_FILE.value, 'w') as keys_file:
+    with open(_KEYS_FILE.value, 'w', encoding='utf-8') as keys_file:
       for key in all_keys:
         keys_file.write(f'{key}\n')
 

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -111,8 +111,12 @@ class GenerateDefaultTraceTest(absltest.TestCase):
         output_path=os.path.join(tmp_dir.full_path, 'output'),
         output_performance_path=os.path.join(tmp_dir.full_path,
                                              'output_performance'),
-    ):
+        keys_file=os.path.join(tmp_dir.full_path, 'keys_file')):
       generate_default_trace.generate_trace()
+
+    with open(os.path.join(tmp_dir.full_path, 'keys_file')) as keys_file:
+      keys = [key_line.strip() for key_line in keys_file.readlines()]
+      self.assertListEqual(keys, ['default', 'default', 'default', 'default'])
 
 
 if __name__ == '__main__':

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -61,16 +61,17 @@ class MockCompilationRunner(compilation_runner.CompilationRunner):
     sequence_example = text_format.Parse(sequence_example_text,
                                          tf.train.SequenceExample())
 
+    key = f'key_{os.getpid()}'
     return compilation_runner.CompilationResult(
         sequence_examples=[sequence_example],
         reward_stats={
-            'default':
+            key:
                 compilation_runner.RewardStat(
                     default_reward=1, moving_average_reward=2)
         },
         rewards=[1.2],
         policy_rewards=[18],
-        keys=['default'],
+        keys=[key],
         model_id=model_id)
 
 
@@ -118,7 +119,8 @@ class GenerateDefaultTraceTest(absltest.TestCase):
         os.path.join(tmp_dir.full_path, 'keys_file'),
         encoding='utf-8') as keys_file:
       keys = [key_line.strip() for key_line in keys_file.readlines()]
-      self.assertListEqual(keys, ['default', 'default', 'default', 'default'])
+      for key in keys:
+        self.assertStartsWith(key, 'key_')
 
 
 if __name__ == '__main__':

--- a/compiler_opt/tools/generate_default_trace_test.py
+++ b/compiler_opt/tools/generate_default_trace_test.py
@@ -114,7 +114,9 @@ class GenerateDefaultTraceTest(absltest.TestCase):
         keys_file=os.path.join(tmp_dir.full_path, 'keys_file')):
       generate_default_trace.generate_trace()
 
-    with open(os.path.join(tmp_dir.full_path, 'keys_file')) as keys_file:
+    with open(
+        os.path.join(tmp_dir.full_path, 'keys_file'),
+        encoding='utf-8') as keys_file:
       keys = [key_line.strip() for key_line in keys_file.readlines()]
       self.assertListEqual(keys, ['default', 'default', 'default', 'default'])
 


### PR DESCRIPTION
This patch adds an option to generate_default_trace to output the keys associated with the examples. This is primarily intended for use in extracting functions that contain eviction decisions to improve the efficiency of the new training workflow for ES regalloc trace modelling. However, this might also be useful in other circumstances if more introspection into the data is needed.