### PR TITLE
Name scalar based on percentile to report

### DIFF
--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -196,7 +196,7 @@ class BlackboxLearner:
       for percentile_to_report in _PERCENTILES_TO_REPORT:
         percentile_value = np.percentile(rewards, percentile_to_report)
         tf.summary.scalar(
-            f'reward/{percentile_value}_percentile',
+            f'reward/{percentile_to_report}_percentile',
             percentile_value,
             step=self._step)
 


### PR DESCRIPTION
Before this patch, the scalar name would end up as containing the value of the percentile rather than the percentile that we are trying to compute. We then end up with a bunch of one point metrics which clutters the UI and also means we cannot get any information about the actual percentiles. This patch fixes that by actually naming the scalar after the percentile that we are trying to compute.