### PR TITLE
Fix saving best policy in ES

### DIFF
--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -32,7 +32,7 @@ class BlackboxEvaluatorTests(absltest.TestCase):
         blackbox_test_utils.ESWorker,
         count=3,
         worker_args=('',),
-        worker_kwargs=dict(kwarg='')) as pool:
+        worker_kwargs={}) as pool:
       perturbations = [b'00', b'01', b'10']
       evaluator = blackbox_evaluator.SamplingBlackboxEvaluator(
           None, blackbox_optimizers.EstimatorType.FORWARD_FD, 5, None)

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -276,14 +276,14 @@ class BlackboxLearner:
 
     if self._config.save_best_policy and np.max(
         rewards) > self._global_max_reward:
-      self._global_max = np.max(rewards)
+      self._global_max_reward = np.max(rewards)
       logging.info('Found new best model with reward %f at step '
-                   '%d, saving.', self._global_max, self._step)
+                   '%d, saving.', self._global_max_reward, self._step)
       max_index = np.argmax(rewards)
       perturbation = initial_perturbations[max_index]
       self._policy_saver_fn(
           parameters=self._model_weights + perturbation,
-          policy_name=f'best_policy_{self._global_max}_step_{self._step}',
+          policy_name=f'best_policy_{self._global_max_reward}_step_{self._step}',
       )
 
     self._save_model()

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -283,7 +283,8 @@ class BlackboxLearner:
       perturbation = initial_perturbations[max_index]
       self._policy_saver_fn(
           parameters=self._model_weights + perturbation,
-          policy_name=f'best_policy_{self._global_max_reward}_step_{self._step}',
+          policy_name=f'best_policy_{self._global_max_reward}_step'
+          '_{self._step}',
       )
 
     self._save_model()

--- a/compiler_opt/es/blackbox_learner.py
+++ b/compiler_opt/es/blackbox_learner.py
@@ -284,7 +284,7 @@ class BlackboxLearner:
       self._policy_saver_fn(
           parameters=self._model_weights + perturbation,
           policy_name=f'best_policy_{self._global_max_reward}_step'
-          '_{self._step}',
+          f'_{self._step}',
       )
 
     self._save_model()

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -158,7 +158,7 @@ class BlackboxLearnerTests(absltest.TestCase):
         count=3,
         pickle_func=cloudpickle.dumps,
         worker_args=('',),
-        worker_kwargs=dict(kwarg='')) as pool:
+        worker_kwargs={}) as pool:
       self._learner.run_step(pool)  # pylint: disable=protected-access
       # expected length calculated from expected shapes of variables
       self.assertEqual(len(self._learner.get_model_weights()), 17154)
@@ -173,8 +173,24 @@ class BlackboxLearnerTests(absltest.TestCase):
         count=3,
         pickle_func=cloudpickle.dumps,
         worker_args=('',),
-        worker_kwargs=dict(kwarg='')) as pool:
+        worker_kwargs={}) as pool:
       self._learner.run_step(pool)
-      self.assertIn("best_policy_2.0_step_0", self._saved_policies)
+      self.assertIn('best_policy_2.0_step_0', self._saved_policies)
       self._learner.run_step(pool)
-      self.assertIn("best_policy_4.0_step_1", self._saved_policies)
+      self.assertIn('best_policy_4.0_step_1', self._saved_policies)
+
+  def test_save_best_model_only_saves_best(self):
+    with local_worker_manager.LocalWorkerPoolManager(
+        blackbox_test_utils.ESWorker,
+        count=3,
+        pickle_func=cloudpickle.dumps,
+        worker_args=('',),
+        worker_kwargs={'delta': -1.0, 'initial_value': 5}) as pool:
+      self._learner.run_step(pool)
+      self.assertIn('best_policy_4.0_step_0', self._saved_policies)
+
+      # Check that the within the next step we only get a new iteration
+      # policy and do not save any new best.
+      current_policies_count = len(self._saved_policies)
+      self._learner.run_step(pool)
+      self.assertLen(self._saved_policies, current_policies_count + 1)

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -185,7 +185,10 @@ class BlackboxLearnerTests(absltest.TestCase):
         count=3,
         pickle_func=cloudpickle.dumps,
         worker_args=('',),
-        worker_kwargs={'delta': -1.0, 'initial_value': 5}) as pool:
+        worker_kwargs={
+            'delta': -1.0,
+            'initial_value': 5
+        }) as pool:
       self._learner.run_step(pool)
       self.assertIn('best_policy_4.0_step_0', self._saved_policies)
 

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -125,7 +125,7 @@ class BlackboxLearnerTests(absltest.TestCase):
     self._learner = blackbox_learner.BlackboxLearner(
         blackbox_opt=blackbox_optimizers.MonteCarloBlackboxOptimizer(
             precision_parameter=1.0,
-            estimator_type=blackbox_optimizers.EstimatorType.ANTITHETIC,
+            estimator_type=blackbox_optimizers.EstimatorType.FORWARD_FD,
             normalize_fvalues=True,
             hyperparameters_update_method=blackbox_optimizers.UpdateMethod
             .NO_METHOD,

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -28,15 +28,15 @@ class ESWorker(worker.Worker):
   Each time a worker is called, the function value
   it will return increases."""
 
-  def __init__(self, arg, *, kwarg):
+  def __init__(self, arg, *, delta = 1.0, initial_value = 0.0):
     self._arg = arg
-    self._kwarg = kwarg
-    self.function_value = 0.0
+    self.function_value = initial_value
+    self._delta = delta
 
   def compile(self, policy: policy_saver.Policy,
               samples: list[corpus.ModuleSpec]) -> float:
     if policy and samples:
-      self.function_value += 1.0
+      self.function_value += self._delta
       return self.function_value
     else:
       return 0.0

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -28,7 +28,7 @@ class ESWorker(worker.Worker):
   Each time a worker is called, the function value
   it will return increases."""
 
-  def __init__(self, arg, *, delta = 1.0, initial_value = 0.0):
+  def __init__(self, arg, *, delta=1.0, initial_value=0.0):
     self._arg = arg
     self.function_value = initial_value
     self._delta = delta


### PR DESCRIPTION
The variable name was bad and it wasn't caught by static analysis as we were setting a new variable before actually using it. This caused the best model each iteration to get saved whether or not it was actually better than all previous models.