### PR TITLE
Add test for saving the best model

### DIFF
--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -50,9 +50,9 @@ class BlackboxLearnerTests(absltest.TestCase):
   def setUp(self):
     super().setUp()
 
-    gin.bind_parameter('SamplingBlackboxEvaluator.total_num_perturbations', 5)
+    gin.bind_parameter('SamplingBlackboxEvaluator.total_num_perturbations', 3)
     gin.bind_parameter('SamplingBlackboxEvaluator.num_ir_repeats_within_worker',
-                       5)
+                       1)
 
     self._learner_config = blackbox_learner.BlackboxLearnerConfig(
         total_steps=1,

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -175,6 +175,6 @@ class BlackboxLearnerTests(absltest.TestCase):
         worker_args=('',),
         worker_kwargs=dict(kwarg='')) as pool:
       self._learner.run_step(pool)
-      self.assertIn("best_policy_2.0_step_0", self._saved_policies)
+      self.assertIn('best_policy_2.0_step_0', self._saved_policies)
       self._learner.run_step(pool)
-      self.assertIn("best_policy_4.0_step_1", self._saved_policies)
+      self.assertIn('best_policy_4.0_step_1', self._saved_policies)


### PR DESCRIPTION
This patch adds a unit test to blackbox_learner for testing that we correctly save the best model, or at least that it does get saved.