### PR TITLE
Run ruff and yapf in pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./check-license.sh
+  PreCommit:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: pipx run pre-commit run --all-files
   Envvars:
     runs-on: ubuntu-22.04
     outputs:
@@ -43,16 +48,12 @@ jobs:
     strategy:
       matrix:
         python-version: ${{ fromJSON(needs.Envvars.outputs.version_matrix) }}
-        task: [Typecheck, Lint, Ruff, Yapf, Test]
+        task: [Typecheck, Lint, Test]
         include:
           - task: Typecheck
             cmd: pytype -j auto .
           - task: Lint
             cmd: pylint --rcfile .pylintrc --recursive yes .
-          - task: Ruff
-            cmd: ruff check
-          - task: Yapf
-            cmd: yapf . -drp
           - task: Test
             cmd: pytest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Learn more about this config here: https://pre-commit.com
+
+# To enable these pre-commit hooks:
+# 1. Install pre-commit: `pip install pre-commit`
+#    or if you are using pipx: `pipx install pre-commit`
+#    or if you are using uv: `uv tool install pre-commit`.
+# Then in the project root directory run `pre-commit install`
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      - id: yapf
+        args: [--in-place, --recursive, --parallel]


### PR DESCRIPTION
Use https://pre-commit.com to run linting and formatting utilities like ruff and yapf on developer machines as part of the git commit process.  Run the same process on GitHub Actions to catch any issues from developers who do not have pre-commit installed locally.  This automates linting and formatting before commits are pushed to the repository to eliminate GitHub Actions runs for small issues.

% `pre-commit install`
```
pre-commit installed at .git/hooks/pre-commit
```
% `pre-commit autoupdate`
```
[https://github.com/astral-sh/ruff-pre-commit] already up to date!
[https://github.com/google/yapf] already up to date!
```
% `pre-commit run --all-files --verbose`
```
ruff.....................................................................Passed
- hook id: ruff
- duration: 0.06s

All checks passed!

yapf.....................................................................Passed
- hook id: yapf
- duration: 4.22s
```
Yapf is a bit slow for a pre-commit hook but should still save turnaround time.