### PR TITLE
Set Minimum Cmake Version in Neon Compat Header Dep

### DIFF
--- a/buildbot/build_tflite.sh
+++ b/buildbot/build_tflite.sh
@@ -97,6 +97,7 @@ ninja -C eigen/src/eigen-build install
 # ARM_NEON_2_x86_SSE
 git clone --filter=tree:0 --no-checkout ${NEON_2_SSE_REPOSITORY} ARM_NEON_2_x86_SSE/src/ARM_NEON_2_x86_SSE
 git -C ARM_NEON_2_x86_SSE/src/ARM_NEON_2_x86_SSE checkout ${NEON_2_SSE_TAG}
+sed -i -e 's/3.0/3.5/' ARM_NEON_2_x86_SSE/src/ARM_NEON_2_x86_SSE/CMakeLists.txt
 cmake -GNinja -S ARM_NEON_2_x86_SSE/src/ARM_NEON_2_x86_SSE -B ARM_NEON_2_x86_SSE/src/ARM_NEON_2_x86_SSE-build \
   -DCMAKE_FIND_PACKAGE_PREFER_CONFIG:BOOL=ON \
   -DCMAKE_INSTALL_PREFIX:PATH=${PWD}/ARM_NEON_2_x86_SSE \


### PR DESCRIPTION
This patch changes the minimum CMake version in the neon compatbility header dependency to be compatible with CMake 4.0.0.

This has been opened upstream in
https://github.com/intel/ARM_NEON_2_x86_SSE/pull/80.