### PR TITLE
Fix flaky tests in blackbox_learner_test

### DIFF
--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -170,19 +170,19 @@ class BlackboxLearnerTests(absltest.TestCase):
   def test_save_best_model(self):
     with local_worker_manager.LocalWorkerPoolManager(
         blackbox_test_utils.ESWorker,
-        count=3,
+        count=1,
         pickle_func=cloudpickle.dumps,
         worker_args=('',),
         worker_kwargs={}) as pool:
       self._learner.run_step(pool)
-      self.assertIn('best_policy_2.0_step_0', self._saved_policies)
+      self.assertIn('best_policy_6.0_step_0', self._saved_policies)
       self._learner.run_step(pool)
-      self.assertIn('best_policy_4.0_step_1', self._saved_policies)
+      self.assertIn('best_policy_12.0_step_1', self._saved_policies)
 
   def test_save_best_model_only_saves_best(self):
     with local_worker_manager.LocalWorkerPoolManager(
         blackbox_test_utils.ESWorker,
-        count=3,
+        count=1,
         pickle_func=cloudpickle.dumps,
         worker_args=('',),
         worker_kwargs={


### PR DESCRIPTION
The two new tests introduced around saving the best model would be flaky depending upon how work got scheduled on the worker pool. This was particularly apparent on the github actions workers where apparently there are not enough cores to make things work properly. This patch fixes that issue by only setting up a single worker, ensuring that there are is only one way to schedule the work.