### PR TITLE
Cleanup parameters for test ES workers

### DIFF
--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -29,9 +29,7 @@ class BlackboxEvaluatorTests(absltest.TestCase):
 
   def test_sampling_get_results(self):
     with local_worker_manager.LocalWorkerPoolManager(
-        blackbox_test_utils.ESWorker,
-        count=3,
-        worker_args=('',),
+        blackbox_test_utils.ESWorker, count=3, worker_args=(),
         worker_kwargs={}) as pool:
       perturbations = [b'00', b'01', b'10']
       evaluator = blackbox_evaluator.SamplingBlackboxEvaluator(
@@ -60,8 +58,8 @@ class BlackboxEvaluatorTests(absltest.TestCase):
     with local_worker_manager.LocalWorkerPoolManager(
         blackbox_test_utils.ESTraceWorker,
         count=3,
-        worker_args=('',),
-        worker_kwargs=dict(kwarg='')) as pool:
+        worker_args=(),
+        worker_kwargs={}) as pool:
       perturbations = [b'00', b'01', b'10']
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
@@ -77,8 +75,8 @@ class BlackboxEvaluatorTests(absltest.TestCase):
     with local_worker_manager.LocalWorkerPoolManager(
         blackbox_test_utils.ESTraceWorker,
         count=1,
-        worker_args=('',),
-        worker_kwargs=dict(kwarg='')) as pool:
+        worker_args=(),
+        worker_kwargs={}) as pool:
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
           elements=[corpus.ModuleSpec(name='name1', size=1)])

--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -157,7 +157,7 @@ class BlackboxLearnerTests(absltest.TestCase):
         blackbox_test_utils.ESWorker,
         count=3,
         pickle_func=cloudpickle.dumps,
-        worker_args=('',),
+        worker_args=(),
         worker_kwargs={}) as pool:
       self._learner.run_step(pool)  # pylint: disable=protected-access
       # expected length calculated from expected shapes of variables
@@ -172,7 +172,7 @@ class BlackboxLearnerTests(absltest.TestCase):
         blackbox_test_utils.ESWorker,
         count=1,
         pickle_func=cloudpickle.dumps,
-        worker_args=('',),
+        worker_args=(),
         worker_kwargs={}) as pool:
       self._learner.run_step(pool)
       self.assertIn('best_policy_6.0_step_0', self._saved_policies)
@@ -184,7 +184,7 @@ class BlackboxLearnerTests(absltest.TestCase):
         blackbox_test_utils.ESWorker,
         count=1,
         pickle_func=cloudpickle.dumps,
-        worker_args=('',),
+        worker_args=(),
         worker_kwargs={
             'delta': -1.0,
             'initial_value': 5

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -28,8 +28,7 @@ class ESWorker(worker.Worker):
   Each time a worker is called, the function value
   it will return increases."""
 
-  def __init__(self, arg, *, delta=1.0, initial_value=0.0):
-    self._arg = arg
+  def __init__(self, *, delta=1.0, initial_value=0.0):
     self.function_value = initial_value
     self._delta = delta
 
@@ -49,9 +48,7 @@ class ESTraceWorker(worker.Worker):
   different interface than other workers.
   """
 
-  def __init__(self, arg, *, kwarg):
-    del arg  # Unused.
-    del kwarg  # Unused.
+  def __init__(self):
     self._function_value = 0.0
 
   def compile_corpus_and_evaluate(self, modules: Collection[corpus.ModuleSpec],


### PR DESCRIPTION
This patch cleans up parameteres for the test ES workers. Previously they would accept things like an argument and a set of keyword arguments that were never used. Drop these as they are completely unnecessary and make things a bit more cluttered.