### PR TITLE
Make RegallocTraceWorker.build_corpus public

### DIFF
--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -343,10 +343,20 @@ class Corpus:
 
     # don't use add/remove for replace
     add_keys = {k.split('=', maxsplit=1)[0] for k in additional_flags}
-    if add_keys.intersection(
-        set(replace_flags)) or set(delete_flags).intersection(
-            set(replace_flags)) or add_keys.intersection(set(delete_flags)):
-      raise ValueError('do not use add/delete flags to replace')
+    if add_keys.intersection(set(replace_flags)):
+      raise ValueError(
+          'Do not use add/delete flags to replace flags: add flags and '
+          'replace flags intersect: '
+          f'{add_keys.intersection(set(replace_flags))}')
+    elif set(delete_flags).intersection(set(replace_flags)):
+      raise ValueError(
+          'Do not use add/delete flags to replace flags: delete flags and '
+          'replace flags intersect: '
+          f'{set(delete_flags).intersection(set(replace_flags))}')
+    elif add_keys.intersection(set(delete_flags)):
+      raise ValueError(
+          'Do not use add/delete flags to replace flags: add flags and delete '
+          f'flags intersect: {add_keys.intersection(set(delete_flags))}')
 
     if module_filter:
       module_paths = [name for name in module_paths if module_filter(name)]

--- a/compiler_opt/tools/regalloc_trace/extract_functions.py
+++ b/compiler_opt/tools/regalloc_trace/extract_functions.py
@@ -14,6 +14,7 @@
 """Extracts functions specified in a list from a corpus."""
 
 import multiprocessing
+import pathlib
 
 from absl import flags
 from absl import app
@@ -56,6 +57,7 @@ def main(_):
     ]
 
   logging.info("Extracting functions.")
+  pathlib.Path(_OUTPUT_PATH.value).mkdir(parents=True, exist_ok=True)
   extract_functions_lib.extract_functions(functions_to_extract,
                                           function_to_module,
                                           _LLVM_EXTRACT_PATH.value,


### PR DESCRIPTION
This patch makes RegallocTraceWorker.build_corpus public rather than
internal. It is being used in places outside of the class itself so
should have a well defined public API. This patch fixes that, adds
docstrings, and updates users.
