### PR TITLE
Only pull unique values in generate_vocab

### DIFF
--- a/compiler_opt/tools/generate_vocab.py
+++ b/compiler_opt/tools/generate_vocab.py
@@ -127,7 +127,9 @@ def _generate_vocab(feature_values_arrays, feature_name,
   sample_length = math.floor(
       np.shape(feature_values)[0] * FLAGS.sampling_fraction)
   values = rng.choice(feature_values, sample_length, replace=False)
-  bin_edges = np.quantile(values, np.linspace(0, 1, FLAGS.num_buckets))
+  unique_values = np.unique(values)
+  num_buckets = min(FLAGS.num_buckets, len(unique_values))
+  bin_edges = np.quantile(unique_values, np.linspace(0, 1, num_buckets))
   filename = os.path.join(FLAGS.output_dir, f'{feature_name}.buckets')
   with open(filename, 'w', encoding='utf-8') as f:
     for edge in bin_edges:


### PR DESCRIPTION
This patch makes generate_vocab only consider unique values when creating quantile buckets for the individual features. There is no point in mapping multiple of the same value to different values post normalization/bucketization. This only serves to decrease dynamic range. Only looking at unique values preserves the property of increasing dynamic range around areas that have lots of slightly different values. This is especially useful when generating vocab for features that are oftentimes zero or one. In some cases I was seeing <50/1000 actual values with the rest being zeros or ones, which results in models that train poorly.