### PR TITLE
Make create_corpus_for_testing use module_spec command lines

### DIFF
--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -63,7 +63,9 @@ class BlackboxEvaluatorTests(absltest.TestCase):
       perturbations = [b'00', b'01', b'10']
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
-          elements=[corpus.ModuleSpec(name='name1', size=1)])
+          elements=[
+              corpus.ModuleSpec(name='name1', size=1, command_line=('-cc1',))
+          ])
       evaluator = blackbox_evaluator.TraceBlackboxEvaluator(
           test_corpus, blackbox_optimizers.EstimatorType.FORWARD_FD,
           'fake_bb_trace_path', 'fake_function_index_path')
@@ -79,7 +81,9 @@ class BlackboxEvaluatorTests(absltest.TestCase):
         worker_kwargs={}) as pool:
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
-          elements=[corpus.ModuleSpec(name='name1', size=1)])
+          elements=[
+              corpus.ModuleSpec(name='name1', size=1, command_line=('-cc1',))
+          ])
       evaluator = blackbox_evaluator.TraceBlackboxEvaluator(
           test_corpus, blackbox_optimizers.EstimatorType.FORWARD_FD,
           'fake_bb_trace_path', 'fake_function_index_path')
@@ -95,7 +99,9 @@ class BlackboxEvaluatorTests(absltest.TestCase):
     results = [f1, f2]
     test_corpus = corpus.create_corpus_for_testing(
         location=self.create_tempdir().full_path,
-        elements=[corpus.ModuleSpec(name='name1', size=1)])
+        elements=[
+            corpus.ModuleSpec(name='name1', size=1, command_line=('-cc1',))
+        ])
     evaluator = blackbox_evaluator.TraceBlackboxEvaluator(
         test_corpus, blackbox_optimizers.EstimatorType.FORWARD_FD,
         'fake_bb_trace_path', 'fake_function_index_path')

--- a/compiler_opt/rl/corpus.py
+++ b/compiler_opt/rl/corpus.py
@@ -435,8 +435,7 @@ class Corpus:
 
 def create_corpus_for_testing(location: str,
                               elements: list[ModuleSpec],
-                              cmdline: tuple[str, ...] = ('-cc1',),
-                              cmdline_is_override=False,
+                              override_cmdline: tuple[str, ...] | None = None,
                               is_thinlto=False,
                               **kwargs) -> Corpus:
   os.makedirs(location, exist_ok=True)
@@ -444,10 +443,10 @@ def create_corpus_for_testing(location: str,
     with tf.io.gfile.GFile(os.path.join(location, element.name + '.bc'),
                            'wb') as f:
       f.write(bytes([1] * element.size))
-    if not cmdline_is_override:
+    if element.command_line:
       with tf.io.gfile.GFile(
           os.path.join(location, element.name + '.cmd'), 'w') as f:
-        f.write('\0'.join(cmdline))
+        f.write('\0'.join(element.command_line))
     if is_thinlto:
       with tf.io.gfile.GFile(
           os.path.join(location, element.name + '.thinlto.bc'), 'w') as f:
@@ -457,8 +456,8 @@ def create_corpus_for_testing(location: str,
       'modules': [e.name for e in elements],
       'has_thinlto': is_thinlto,
   }
-  if cmdline_is_override:
-    corpus_description['global_command_override'] = cmdline
+  if override_cmdline is not None:
+    corpus_description['global_command_override'] = override_cmdline
   with tf.io.gfile.GFile(
       os.path.join(location, 'corpus_description.json'), 'w') as f:
     f.write(json.dumps(corpus_description))

--- a/compiler_opt/rl/corpus_test.py
+++ b/compiler_opt/rl/corpus_test.py
@@ -80,7 +80,9 @@ class ModuleSpecTest(tf.test.TestCase):
   def test_loadable_spec(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name='smth', size=1)])
+        elements=[
+            corpus.ModuleSpec(name='smth', size=1, command_line=('-cc1',))
+        ])
     lms = cps.load_module_spec(cps.module_specs[0])
     corpdir2 = self.create_tempdir()
     fqcmd = lms.build_command_line(corpdir2)
@@ -95,7 +97,7 @@ class CorpusTest(tf.test.TestCase):
   def test_constructor(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name='1', size=1)],
+        elements=[corpus.ModuleSpec(name='1', size=1, command_line=('-cc1',))],
         additional_flags=('-add',))
     self.assertEqual(cps.module_specs, (corpus.ModuleSpec(
         name='1',
@@ -109,15 +111,17 @@ class CorpusTest(tf.test.TestCase):
         ValueError, msg='-cc1 flag not present in .cmd file'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-hi',))
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-h1',))
+          ])
 
     with self.assertRaises(
         ValueError, msg='do not use add/delete flags to replace'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-cc1',),
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+          ],
           additional_flags=('-fsomething',),
           replace_flags={'-fsomething': 'does not matter'})
 
@@ -125,8 +129,9 @@ class CorpusTest(tf.test.TestCase):
         ValueError, msg='do not use add/delete flags to replace'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-cc1',),
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+          ],
           additional_flags=('-fsomething=new_value',),
           replace_flags={'-fsomething': 'does not matter'})
 
@@ -134,8 +139,9 @@ class CorpusTest(tf.test.TestCase):
         ValueError, msg='do not use add/delete flags to replace'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-cc1',),
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+          ],
           delete_flags=('-fsomething',),
           replace_flags={'-fsomething': 'does not matter'})
 
@@ -143,8 +149,9 @@ class CorpusTest(tf.test.TestCase):
         ValueError, msg='do not use add/delete flags to replace'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-cc1',),
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+          ],
           additional_flags=('-fsomething',),
           delete_flags=('-fsomething',))
 
@@ -152,8 +159,9 @@ class CorpusTest(tf.test.TestCase):
         ValueError, msg='do not use add/delete flags to replace'):
       corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
-          elements=[corpus.ModuleSpec(name='smol', size=1)],
-          cmdline=('-cc1',),
+          elements=[
+              corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+          ],
           additional_flags=('-fsomething=value',),
           delete_flags=('-fsomething',))
 
@@ -163,13 +171,17 @@ class CorpusTest(tf.test.TestCase):
         ValueError,
         msg=f'{location}\'s corpus_description contains no modules.'):
       corpus.create_corpus_for_testing(
-          location=self.create_tempdir(), elements=[], cmdline=('-hello',))
+          location=self.create_tempdir(), elements=[])
 
   def test_ctor_thinlto(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name='smol', size=1)],
-        cmdline=('-cc1', '-fthinlto-index=foo'),
+        elements=[
+            corpus.ModuleSpec(
+                name='smol',
+                size=1,
+                command_line=('-cc1', '-fthinlto-index=foo'))
+        ],
         is_thinlto=True)
     self.assertIn('-fthinlto-index={context.thinlto_full_path}',
                   cps.module_specs[0].command_line)
@@ -181,8 +193,12 @@ class CorpusTest(tf.test.TestCase):
     corpusdir = self.create_tempdir()
     cps = corpus.create_corpus_for_testing(
         location=corpusdir,
-        elements=[corpus.ModuleSpec(name='somename', size=1)],
-        cmdline=('-cc1', r'-DMACRO(expr)=do {} while(0)'),
+        elements=[
+            corpus.ModuleSpec(
+                name='somename',
+                size=1,
+                command_line=('-cc1', r'-DMACRO(expr)=do {} while(0)'))
+        ],
         additional_flags=('-additional_flag={context.module_full_path}',))
     mod_spec = cps.module_specs[0]
     loaded_spec = cps.load_module_spec(mod_spec)
@@ -197,8 +213,7 @@ class CorpusTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[corpus.ModuleSpec(name='smol', size=1)],
-        cmdline=(),
-        cmdline_is_override=True,
+        override_cmdline=(),
         is_thinlto=True)
     self.assertNotIn('-fthinlto-index', cps.module_specs[0].command_line)
     self.assertEqual(cps.module_specs[0].command_line[-6:],
@@ -209,8 +224,7 @@ class CorpusTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[corpus.ModuleSpec(name='smol', size=1)],
-        cmdline=('-something',),
-        cmdline_is_override=True,
+        override_cmdline=('-something',),
         is_thinlto=True)
     self.assertIn('-fthinlto-index={context.thinlto_full_path}',
                   cps.module_specs[0].command_line)
@@ -224,10 +238,10 @@ class CorpusTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[
-            corpus.ModuleSpec(name='smol', size=1),
-            corpus.ModuleSpec(name='middle', size=200),
-            corpus.ModuleSpec(name='largest', size=500),
-            corpus.ModuleSpec(name='small', size=100)
+            corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='middle', size=200, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='largest', size=500, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='small', size=100, command_line=('-cc1',))
         ])
     sample = cps.sample(4, sort=True)
     self.assertLen(sample, 4)
@@ -240,10 +254,10 @@ class CorpusTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[
-            corpus.ModuleSpec(name='smol', size=1),
-            corpus.ModuleSpec(name='middle', size=200),
-            corpus.ModuleSpec(name='largest', size=500),
-            corpus.ModuleSpec(name='small', size=100)
+            corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='middle', size=200, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='largest', size=500, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='small', size=100, command_line=('-cc1',))
         ],
         sampler_type=corpus.SamplerWithoutReplacement)
     samples = []
@@ -270,10 +284,10 @@ class CorpusTest(tf.test.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[
-            corpus.ModuleSpec(name='smol', size=1),
-            corpus.ModuleSpec(name='middle', size=200),
-            corpus.ModuleSpec(name='largest', size=500),
-            corpus.ModuleSpec(name='small', size=100)
+            corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='middle', size=200, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='largest', size=500, command_line=('-cc1',)),
+            corpus.ModuleSpec(name='small', size=100, command_line=('-cc1',))
         ],
         module_filter=lambda name: re.compile(r'.+l').match(name))
     sample = cps.sample(999, sort=True)
@@ -285,7 +299,9 @@ class CorpusTest(tf.test.TestCase):
   def test_sample_zero(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name='smol', size=1)])
+        elements=[
+            corpus.ModuleSpec(name='smol', size=1, command_line=('-cc1',))
+        ])
 
     self.assertRaises(ValueError, cps.sample, 0)
     self.assertRaises(ValueError, cps.sample, -213213213)
@@ -293,7 +309,10 @@ class CorpusTest(tf.test.TestCase):
   def test_bucket_sample(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name=f'{i}', size=i) for i in range(100)])
+        elements=[
+            corpus.ModuleSpec(name=f'{i}', size=i, command_line=('-cc1',))
+            for i in range(100)
+        ])
     # Odds of passing once by pure luck with random.sample: 1.779e-07
     # Try 32 times, for good measure.
     for i in range(32):
@@ -309,7 +328,10 @@ class CorpusTest(tf.test.TestCase):
     # Create corpus with a prime number of modules.
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name=f'{i}', size=i) for i in range(101)])
+        elements=[
+            corpus.ModuleSpec(name=f'{i}', size=i, command_line=('-cc1',))
+            for i in range(101)
+        ])
 
     # Try 32 times, for good measure.
     for i in range(32):
@@ -323,7 +345,10 @@ class CorpusTest(tf.test.TestCase):
     # Make sure we can sample even when k < n.
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name=f'{i}', size=i) for i in range(100)])
+        elements=[
+            corpus.ModuleSpec(name=f'{i}', size=i, command_line=('-cc1',))
+            for i in range(100)
+        ])
 
     # Try all 19 possible values 0 < i < n
     for i in range(1, 20):

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -151,7 +151,9 @@ class LocalDataCollectorTest(tf.test.TestCase):
       cps = corpus.create_corpus_for_testing(
           location=self.create_tempdir(),
           elements=[
-              corpus.ModuleSpec(name=f'dummy{i}', size=i) for i in range(100)
+              corpus.ModuleSpec(
+                  name=f'dummy{i}', size=i, command_line=('-cc1',))
+              for i in range(100)
           ],
           sampler_type=DeterministicSampler)
       collector = local_data_collector.LocalDataCollector(
@@ -213,7 +215,8 @@ class LocalDataCollectorTest(tf.test.TestCase):
           cps=corpus.create_corpus_for_testing(
               location=self.create_tempdir(),
               elements=[
-                  corpus.ModuleSpec(name=f'dummy{i}', size=1)
+                  corpus.ModuleSpec(
+                      name=f'dummy{i}', size=1, command_line=('-cc1',))
                   for i in range(200)
               ]),
           num_modules=4,


### PR DESCRIPTION
This patch makes create_corpus_for_testing use the command lines from
individual modle_specs passed in as elements rather than using the same
command line for all the modules. This is needed for testing the group
functions library.
