### PR TITLE
Fixing tests due to recent changes

### DIFF
--- a/compiler_opt/es/blackbox_evaluator_test.py
+++ b/compiler_opt/es/blackbox_evaluator_test.py
@@ -51,7 +51,9 @@ class BlackboxEvaluatorTests(absltest.TestCase):
         worker_kwargs={}) as pool:
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
-          elements=[corpus.ModuleSpec(name='name1', size=10)])
+          elements=[
+              corpus.ModuleSpec(name='name1', size=10, command_line=('-cc1',))
+          ])
       evaluator = blackbox_evaluator.SamplingBlackboxEvaluator(
           test_corpus, blackbox_optimizers.EstimatorType.FORWARD_FD, 1, 1)
 
@@ -72,7 +74,9 @@ class BlackboxEvaluatorTests(absltest.TestCase):
         worker_kwargs={}) as pool:
       test_corpus = corpus.create_corpus_for_testing(
           location=self.create_tempdir().full_path,
-          elements=[corpus.ModuleSpec(name='name1', size=1)])
+          elements=[
+              corpus.ModuleSpec(name='name1', size=1, command_line=('-cc1',))
+          ])
       evaluator = blackbox_evaluator.SamplingBlackboxEvaluator(
           test_corpus, blackbox_optimizers.EstimatorType.FORWARD_FD, 2, 1)
 

--- a/compiler_opt/es/inlining/inlining_worker_test.py
+++ b/compiler_opt/es/inlining/inlining_worker_test.py
@@ -43,8 +43,8 @@ class InliningWorkerTest(absltest.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[
-            corpus.ModuleSpec(name="smth1", size=1),
-            corpus.ModuleSpec(name="smth2", size=1)
+            corpus.ModuleSpec(name="smth1", size=1, command_line=("-cc1",)),
+            corpus.ModuleSpec(name="smth2", size=1, command_line=("-cc1",))
         ])
     loaded_modules = [
         cps.load_module_spec(cps.module_specs[0]),
@@ -96,8 +96,8 @@ class InliningWorkerTest(absltest.TestCase):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
         elements=[
-            corpus.ModuleSpec(name="smth1", size=1),
-            corpus.ModuleSpec(name="smth2", size=1)
+            corpus.ModuleSpec(name="smth1", size=1, command_line=("-cc1",)),
+            corpus.ModuleSpec(name="smth2", size=1, command_line=("-cc1",))
         ])
     loaded_modules = [
         cps.load_module_spec(cps.module_specs[0]),
@@ -156,7 +156,9 @@ class InliningWorkerTest(absltest.TestCase):
   def test_compile_failure_returns_none(self):
     cps = corpus.create_corpus_for_testing(
         location=self.create_tempdir(),
-        elements=[corpus.ModuleSpec(name="smth1", size=1)])
+        elements=[
+            corpus.ModuleSpec(name="smth1", size=1, command_line=("-cc1",))
+        ])
     loaded_modules = [cps.load_module_spec(cps.module_specs[0])]
 
     fake_clang_binary = self.create_tempfile("fake_clang")


### PR DESCRIPTION
Tests related to es inliner breaks due to recent changes related to `command_line` in `ModuleSpec`. This patch fixes that.