### PR TITLE
Restore best model test functionality

### DIFF
--- a/compiler_opt/es/blackbox_learner_test.py
+++ b/compiler_opt/es/blackbox_learner_test.py
@@ -177,8 +177,8 @@ class BlackboxLearnerTests(absltest.TestCase):
         pickle_func=cloudpickle.dumps,
         worker_args=(),
         worker_kwargs={
-          'delta': -1.0,
-          'initial_value': 5
+            'delta': -1.0,
+            'initial_value': 5
         }) as pool:
       self._learner.set_baseline(pool)
       self._learner.run_step(pool)

--- a/compiler_opt/es/blackbox_test_utils.py
+++ b/compiler_opt/es/blackbox_test_utils.py
@@ -20,6 +20,7 @@ import gin
 from compiler_opt.distributed import worker
 from compiler_opt.rl import corpus
 from compiler_opt.rl import policy_saver
+from compiler_opt.rl import constant
 
 
 @gin.configurable
@@ -34,11 +35,14 @@ class ESWorker(worker.Worker):
 
   def compile(self, policy: policy_saver.Policy,
               modules: list[corpus.LoadedModuleSpec]) -> float:
+    # We return the values with constant.DELTA subtracted so that we get
+    # exact values we can assert against when writing tests that only see
+    # the relative reward.
     if policy and modules:
       self.function_value += self._delta
-      return self.function_value
+      return self.function_value - constant.DELTA
     else:
-      return 0.0
+      return 100 - constant.DELTA
 
 
 class SizeReturningESWorker(worker.Worker):


### PR DESCRIPTION
Some of the tests around the "save best model" functionality were
changed up in 6cf15b30ea80282a7a74e7c07092af2887cc1a86 as it touched
SamplingBlackboxEvaluator which is used in the tests in a way that made
them not work. This patch restores the functionality by changing up how
the tests work a bit so they test what they are intended to.
