### PR TITLE
[Dockerfile] Update the docker file to include all pipenv dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10
 
 WORKDIR /ml-compiler-opt
 COPY . .
-RUN pip install pipenv && pipenv sync --system && pipenv --clear
+RUN pip install pipenv && pipenv sync --system --categories "packages,dev-packages,ci" && pipenv --clear
 
 WORKDIR /ml-compiler-opt/compiler_opt/tools
 ENV PYTHONPATH=/ml-compiler-opt


### PR DESCRIPTION
This patch updates the "Dockerfile" so it uses the pipenv to install
all dependencies from the Pipfile.
