### PR TITLE
[buildbot] Install nanobind for IR2Vec Python bindings on ml-opt bots

### DIFF
--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -133,9 +133,10 @@ python3 -m pip install --break-system-packages buildbot-worker==2.9.0
 echo installed buildbot worker
 
 # Install IR2Vec Python binding dependencies.
-# Version constraints are defined in llvm-project:
+# Installs from llvm-project main; canonical source is
 # llvm/tools/llvm-ir2vec/Bindings/requirements.txt
-python3 -m pip install --break-system-packages "nanobind>=2.9,<3.0"
+python3 -m pip install --break-system-packages \
+  -r https://raw.githubusercontent.com/llvm/llvm-project/main/llvm/tools/llvm-ir2vec/Bindings/requirements.txt
 
 TF_PIP=$(sudo -u buildbot python3 -c "import tensorflow as tf; import os; print(os.path.dirname(tf.__file__))")
 

--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -132,6 +132,11 @@ popd
 python3 -m pip install --break-system-packages buildbot-worker==2.9.0
 echo installed buildbot worker
 
+# Install IR2Vec Python binding dependencies.
+# Version constraints are defined in llvm-project:
+# llvm/tools/llvm-ir2vec/Bindings/requirements.txt
+python3 -m pip install --break-system-packages "nanobind>=2.9,<3.0"
+
 TF_PIP=$(sudo -u buildbot python3 -c "import tensorflow as tf; import os; print(os.path.dirname(tf.__file__))")
 
 # temp location until zorg updates


### PR DESCRIPTION
This is a prerequisite for enabling IR2Vec Python binding tests on the ml-opt buildbots (tracked in llvm/llvm-zorg [HERE](https://github.com/llvm/llvm-zorg/pull/846) )

The change itself is 
- Install `nanobind>=2.9,<3.0` on ml-opt workers at boot time.

- nanobind is a build-time dependency of LLVM's IR2Vec Python bindings, not a runtime dependency of ml-compiler-opt. Adding it to the Pipfile would misrepresent its ownership. 

- The requirement itself mirrors `llvm/tools/llvm-ir2vec/Bindings/requirements.txt` in llvm-project. ( to be merged [HERE](https://github.com/llvm/llvm-project/pull/194593))

If that constraint changes, this line should be updated accordingly. Currently, I don't see a way to have a single source of truth and propagate it to this repo.

- This PR must merge and workers must be rebooted before the llvm-zorg PR (which sets -DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON) is merged.

Adding @boomanaiden154  , @svkeerthy  for reference 

- PR for llvm-project change : https://github.com/llvm/llvm-project/pull/194593 
- PR for llvm-zorg change : https://github.com/llvm/llvm-zorg/pull/846 