### PR TITLE
Use env variable for LLVM_MAJOR_VERSION

### DIFF
--- a/buildbot/buildbot_init.sh
+++ b/buildbot/buildbot_init.sh
@@ -87,10 +87,11 @@ ADMIN_PACKAGES="tmux"
         software-properties-common \
         gnupg
 
-      bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" 20
-      ln -sf /usr/bin/clang-22 /usr/bin/cc
-      ln -sf /usr/bin/clang++-22 /usr/bin/c++
-      ln -sf /usr/bin/ld.lld-22 /usr/bin/ld
+      export LLVM_MAJOR_VERSION=22
+      bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ${LLVM_MAJOR_VERSION}
+      ln -sf /usr/bin/clang-${LLVM_MAJOR_VERSION} /usr/bin/cc
+      ln -sf /usr/bin/clang++-${LLVM_MAJOR_VERSION} /usr/bin/c++
+      ln -sf /usr/bin/ld.lld-${LLVM_MAJOR_VERSION} /usr/bin/ld
 
     ) && exit 0
   done


### PR DESCRIPTION
After 9830980ad85f617a3dd722cf75020f87ed7ff432, the version the script was supposed to install (although probably did not due to apt.llvm.org shenanigans) and the symlinks did not match. Use a common environment variable to avoid needing to update all the numbers separately.