### PR TITLE
Make `start_cancellable_process` arguments more pass-through to `Popen`

### DIFF
--- a/compiler_opt/rl/compilation_runner.py
+++ b/compiler_opt/rl/compilation_runner.py
@@ -150,7 +150,7 @@ class WorkerCancellationManager:
   managing resources.
   """
 
-  def __init__(self):
+  def __init__(self, timeout: float | None = None):
     # the queue is filled only by workers, and drained only by the single
     # consumer. we use _done to manage access to the queue. We can then assume
     # empty() is accurate and get() never blocks.
@@ -158,6 +158,7 @@ class WorkerCancellationManager:
     self._done = False
     self._paused = False
     self._lock = threading.Lock()
+    self._timeout = timeout
 
   def enable(self):
     with self._lock:
@@ -207,66 +208,57 @@ class WorkerCancellationManager:
     if len(self._processes) > 0:
       raise RuntimeError('Cancellation manager deleted while containing items.')
 
-
-def start_cancellable_process(
-    cmdline: list[str],
-    timeout: float,
-    cancellation_manager: WorkerCancellationManager
-    | None,
-    want_output: bool = False,
-    **kwargs,
-) -> bytes | str | None:
-  """Start a cancellable process.
-
-  Args:
-    cmdline: the process executable and command line
-    timeout: process execution timeout
-    cancellation_manager: kill any running process if signaled to do so
-    want_output: if True, return a buffer containing stdout
-
-  Returns:
-    stdout
-  Raises:
-    CalledProcessError: if the process encounters an error.
-    TimeoutExpired: if the process times out.
-    ProcessKilledError: if the process was killed via the cancellation token.
-  """
-  command_env = os.environ.copy()
-  # Disable tensorflow info messages during data collection
-  if _QUIET.value:
-    command_env['TF_CPP_MIN_LOG_LEVEL'] = '1'
-  else:
-    logging.info(shlex.join(cmdline))
-  with subprocess.Popen(
-      cmdline,
-      env=command_env,
-      stdout=(subprocess.PIPE if want_output else None),
+  def start_cancellable_process(
+      self,
+      cmdline: list[str],
       **kwargs,
-  ) as p:
-    if cancellation_manager:
-      cancellation_manager.register_process(p)
+  ) -> bytes | str | None:
+    """Start a cancellable process.
 
-    try:
-      retcode = p.wait(timeout=timeout)
-    except subprocess.TimeoutExpired as e:
-      logging.info('Command hit timeout: %s', shlex.join(cmdline))
-      kill_process_ignore_exceptions(p)
-      raise e
-    finally:
-      if cancellation_manager:
-        cancellation_manager.unregister_process(p)
+    Args:
+      cmdline: the process executable and command line
+      **kwargs: keyword arguments to subprocess.Popen (e.g. stdout, env)
 
-    if retcode != 0:
-      if retcode == -9:
-        raise ProcessKilledError()
-      logging.info('Command returned code %d: %s', retcode, shlex.join(cmdline))
-      raise subprocess.CalledProcessError(retcode, cmdline)
+    Returns:
+      stdout if stdout=subprocess.PIPE was requested, else None.
+    Raises:
+      CalledProcessError: if the process encounters an error.
+      TimeoutExpired: if the process times out.
+      ProcessKilledError: if the process was killed via the cancellation token.
+    """
+    env = kwargs.pop('env', None)
+    command_env = env.copy() if env is not None else os.environ.copy()
+    if _QUIET.value:
+      command_env['TF_CPP_MIN_LOG_LEVEL'] = '1'
     else:
-      if want_output:
-        assert p.stdout is not None
-        ret: bytes = p.stdout.read()
-        p.stdout.close()
-        return ret
+      logging.info(shlex.join(cmdline))
+    with subprocess.Popen(
+        cmdline,
+        env=command_env,
+        **kwargs,
+    ) as p:
+      self.register_process(p)
+
+      try:
+        retcode = p.wait(timeout=self._timeout)
+      except subprocess.TimeoutExpired as e:
+        logging.info('Command hit timeout: %s', shlex.join(cmdline))
+        kill_process_ignore_exceptions(p)
+        raise e
+      finally:
+        self.unregister_process(p)
+
+      if retcode != 0:
+        if retcode == -9:
+          raise ProcessKilledError()
+        logging.info('Command returned code %d: %s', retcode,
+                     shlex.join(cmdline))
+        raise subprocess.CalledProcessError(retcode, cmdline)
+      else:
+        if p.stdout:
+          ret = p.stdout.read()
+          p.stdout.close()
+          return ret
 
 
 @dataclasses.dataclass(frozen=True)
@@ -391,7 +383,8 @@ class CompilationRunner(Worker):
     self._moving_average_decay_rate = moving_average_decay_rate
     # Avoid reading the flag during the first interpretation of this module.
     self._compilation_timeout = COMPILATION_TIMEOUT.value
-    self._cancellation_manager = WorkerCancellationManager()
+    self._cancellation_manager = WorkerCancellationManager(
+        timeout=self._compilation_timeout)
     self._observers = ([f() for f in create_observer_fns]
                        if create_observer_fns else [])
 

--- a/compiler_opt/rl/compilation_runner_test.py
+++ b/compiler_opt/rl/compilation_runner_test.py
@@ -216,13 +216,10 @@ class CompilationRunnerTest(tf.test.TestCase):
     self.assertEqual(1, mock_compile_fn.call_count)
 
   def test_start_subprocess_output(self):
-    cm = compilation_runner.WorkerCancellationManager()
-    output_str = compilation_runner.start_cancellable_process(
-        ['ls', '-l'],
-        timeout=100,
-        cancellation_manager=cm,
-        want_output=True,
-        text=True)
+    cm = compilation_runner.WorkerCancellationManager(timeout=100)
+    output_str = cm.start_cancellable_process(['ls', '-l'],
+                                              stdout=subprocess.PIPE,
+                                              text=True)
     if not output_str:
       self.fail('output should have been non-empty')
     self.assertNotEmpty(output_str)
@@ -232,16 +229,15 @@ class CompilationRunnerTest(tf.test.TestCase):
                                  'test_timeout_kills_test_file')
     if os.path.exists(sentinel_file):
       os.remove(sentinel_file)
+    cm = compilation_runner.WorkerCancellationManager(timeout=0.5)
     with self.assertRaises(subprocess.TimeoutExpired):
-      compilation_runner.start_cancellable_process(
-          ['bash', '-c', 'sleep 1s ; touch ' + sentinel_file],
-          timeout=0.5,
-          cancellation_manager=None)
+      cm.start_cancellable_process(
+          ['bash', '-c', 'sleep 1s ; touch ' + sentinel_file])
     time.sleep(2)
     self.assertFalse(os.path.exists(sentinel_file))
 
   def test_pause_resume(self):
-    cm = compilation_runner.WorkerCancellationManager()
+    cm = compilation_runner.WorkerCancellationManager(timeout=30)
     start_time = time.time()
 
     def stop_and_start():
@@ -251,9 +247,7 @@ class CompilationRunnerTest(tf.test.TestCase):
       cm.resume_all_processes()
 
     threading.Thread(target=stop_and_start).start()
-    compilation_runner.start_cancellable_process(['sleep', '0.5'],
-                                                 30,
-                                                 cancellation_manager=cm)
+    cm.start_cancellable_process(['sleep', '0.5'])
     # should be at least 1 second due to the pause.
     self.assertGreater(time.time() - start_time, 1)
 

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -93,16 +93,10 @@ class InliningRunner(compilation_runner.CompilationRunner):
     if tf_policy_path:
       cmdline.extend(
           ['-mllvm', '-ml-inliner-model-under-training=' + tf_policy_path])
-    compilation_runner.start_cancellable_process(cmdline,
-                                                 self._compilation_timeout,
-                                                 self._cancellation_manager)
+    self._cancellation_manager.start_cancellable_process(cmdline)
     cmdline = [self._llvm_size_path, output_native_path]
-    output = compilation_runner.start_cancellable_process(
-        cmdline,
-        timeout=self._compilation_timeout,
-        cancellation_manager=self._cancellation_manager,
-        want_output=True,
-        text=True)
+    output = self._cancellation_manager.start_cancellable_process(
+        cmdline, stdout=subprocess.PIPE, text=True)
     if not output:
       raise RuntimeError(f'Empty llvm-size output: {" ".join(cmdline)}')
     tmp = output.split('\n')

--- a/compiler_opt/rl/inlining/inlining_runner.py
+++ b/compiler_opt/rl/inlining/inlining_runner.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 
 import gin
+import subprocess
 import tensorflow as tf
 
 from compiler_opt.rl import compilation_runner

--- a/compiler_opt/rl/local_data_collector_test.py
+++ b/compiler_opt/rl/local_data_collector_test.py
@@ -92,8 +92,7 @@ class Sleeper(compilation_runner.CompilationRunner):
                    reward_stat=None,
                    model_id=None):
     _ = loaded_module_spec, policy, reward_stat
-    compilation_runner.start_cancellable_process(['sleep', '3600s'], 3600,
-                                                 self._cancellation_manager)
+    self._cancellation_manager.start_cancellable_process(['sleep', '3600s'])
 
     return compilation_runner.CompilationResult(
         sequence_examples=[],

--- a/compiler_opt/rl/regalloc/regalloc_runner.py
+++ b/compiler_opt/rl/regalloc/regalloc_runner.py
@@ -78,9 +78,7 @@ class RegAllocRunner(compilation_runner.CompilationRunner):
 
     if tf_policy_path:
       cmdline.extend(['-mllvm', '-regalloc-model=' + tf_policy_path])
-    compilation_runner.start_cancellable_process(cmdline,
-                                                 self._compilation_timeout,
-                                                 self._cancellation_manager)
+    self._cancellation_manager.start_cancellable_process(cmdline)
 
     # TODO(#202)
     log_result = log_reader.read_log_as_sequence_examples(log_path)

--- a/compiler_opt/rl/regalloc_priority/regalloc_priority_runner.py
+++ b/compiler_opt/rl/regalloc_priority/regalloc_priority_runner.py
@@ -28,9 +28,11 @@ class RegAllocPriorityRunner(compilation_runner.CompilationRunner):
   """Class for collecting data for regalloc-priority-prediction."""
 
   def _compile_fn(
-      self, file_paths: tuple[str, ...], tf_policy_path: str, reward_only: bool,
+      self,
+      file_paths: tuple[str, ...],
+      tf_policy_path: str,
+      reward_only: bool,
       workdir: str,
-      cancellation_manager: compilation_runner.WorkerCancellationManager | None
   ) -> dict[str, tuple[tf.train.SequenceExample, float]]:
 
     file_paths = file_paths[0].replace('.bc', '')
@@ -52,9 +54,7 @@ class RegAllocPriorityRunner(compilation_runner.CompilationRunner):
     if tf_policy_path:
       command_line.extend(
           ['-mllvm', '-regalloc-priority-model=' + tf_policy_path])
-    compilation_runner.start_cancellable_process(command_line,
-                                                 self._compilation_timeout,
-                                                 cancellation_manager)
+    self._cancellation_manager.start_cancellable_process(command_line)
 
     # TODO(#202)
     log_result = log_reader.read_log_as_sequence_examples(log_path)

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -18,7 +18,7 @@ not necessary, but sufficient for illustration.
 2) define the implementation of
 `compiler_opt.rl.compilation_runner.CompilationRunner` that's specific to your
 problem. Refer to the examples. Note how we always start processes via the
-`compiler_opt.rl.start_cancellable_process()` utility.
+`self._cancellation_manager.start_cancellable_process()` utility.
 
 3) define the ML interface - see the `config.py` file in each of the examples.
 


### PR DESCRIPTION
This makes it easy to configure other args to `Popen`, like `env`. We still return just `stdout`, meaning that if we want `stderr` we need to pipe it. TBD if we ever have a scenario where we want them separate.